### PR TITLE
deps(client): migrate from `http-status` to `http-status-codes`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@parcel/service-worker": "^2.8.3",
-        "http-status": "^1.6.2",
+        "http-status-codes": "^2.2.0",
         "svelte-spa-router": "^3.3.0",
         "zod": "^3.21.4"
     }

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@plasmohq/parcel-transformer-svelte3': ^0.4.5
   '@types/serviceworker': ^0.0.66
   cssnano: ^5.1.15
-  http-status: ^1.6.2
+  http-status-codes: ^2.2.0
   parcel: ^2.8.3
   postcss: ^8.4.21
   svelte: ^3.57.0
@@ -21,7 +21,7 @@ specifiers:
 
 dependencies:
   '@parcel/service-worker': 2.8.3
-  http-status: 1.6.2
+  http-status-codes: 2.2.0
   svelte-spa-router: 3.3.0
   zod: 3.21.4
 
@@ -1394,9 +1394,8 @@ packages:
       entities: 3.0.1
     dev: true
 
-  /http-status/1.6.2:
-    resolution: {integrity: sha512-oUExvfNckrpTpDazph7kNG8sQi5au3BeTo0idaZFXEhTaJKu7GNJCLHI0rYY2wljm548MSTM+Ljj/c6anqu2zQ==}
-    engines: {node: '>= 0.4.0'}
+  /http-status-codes/2.2.0:
+    resolution: {integrity: sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==}
     dev: false
 
   /import-fresh/3.3.0:

--- a/client/src/api/batch.ts
+++ b/client/src/api/batch.ts
@@ -1,12 +1,4 @@
-import {
-    OK,
-    CREATED,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import {
     type GeneratedBatch,
@@ -31,12 +23,12 @@ export namespace Batch {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return MinBatchSchema.parse(await res.json());
-            case NOT_FOUND: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return MinBatchSchema.parse(await res.json());
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -48,11 +40,11 @@ export namespace Batch {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case CREATED: return GeneratedBatchSchema.parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.CREATED: return GeneratedBatchSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/category.ts
+++ b/client/src/api/category.ts
@@ -1,14 +1,4 @@
-import {
-    OK,
-    CREATED,
-    ACCEPTED,
-    BAD_REQUEST,
-    NO_CONTENT,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { type Category as CategoryType, CategorySchema } from '~model/category.ts';
 
@@ -31,9 +21,9 @@ export namespace Category {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return CategorySchema.array().parse(await res.json());
-            case UNAUTHORIZED: throw new InvalidSession;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return CategorySchema.array().parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -53,11 +43,11 @@ export namespace Category {
             },
         });
         switch (res.status) {
-            case CREATED: return CategorySchema.shape.id.parse(JSON.parse(await res.json()));
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.CREATED: return CategorySchema.shape.id.parse(JSON.parse(await res.json()));
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -77,12 +67,12 @@ export namespace Category {
             },
         });
         switch (res.status) {
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return false;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return false;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -99,12 +89,12 @@ export namespace Category {
             credentials: 'same-origin',
         });
         switch (res.status) {
-            case ACCEPTED: return false;
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.ACCEPTED: return false;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -121,11 +111,11 @@ export namespace Category {
             headers: { 'Accept': 'text/plain' },
         });
         switch (res.status) {
-            case OK: return res.text();
-            case NOT_FOUND: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.OK: return res.text();
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -1,12 +1,4 @@
-import {
-    OK,
-    CREATED,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_ACCEPTABLE,
-    CONFLICT,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import type { Document as DocumentType } from '~model/document.ts';
 import type { Office } from '~model/office.ts';
@@ -45,12 +37,12 @@ export namespace Document {
             },
         });
         switch (res.status) {
-            case CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
-            case CONFLICT: return BarcodeAssignmentErrorSchema.parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
+            case StatusCodes.CONFLICT: return BarcodeAssignmentErrorSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -61,11 +53,11 @@ export namespace Document {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return InboxEntrySchema.array().parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return InboxEntrySchema.array().parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -75,9 +67,9 @@ export namespace Document {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return PaperTrailSchema.array().parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return PaperTrailSchema.array().parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/invite.ts
+++ b/client/src/api/invite.ts
@@ -1,12 +1,4 @@
-import {
-    OK,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-    CONFLICT,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { type Invitation, InvitationSchema } from '~model/invitation.ts';
 
@@ -30,12 +22,12 @@ export namespace Invite {
             },
         });
         switch (res.status) {
-            case OK: return InvitationSchema.shape.creation.parse(await res.json());
-            case CONFLICT: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return InvitationSchema.shape.creation.parse(await res.json());
+            case StatusCodes.CONFLICT: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -51,12 +43,12 @@ export namespace Invite {
             },
         });
         switch (res.status) {
-            case OK: return InvitationSchema.omit({ office: true, email: true }).parse(await res.json());
-            case NOT_FOUND: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return InvitationSchema.omit({ office: true, email: true }).parse(await res.json());
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,9 +1,4 @@
-import {
-    OK,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { type Metrics as MetricsType, MetricsSchema } from '~model/api.ts';
 
@@ -21,10 +16,10 @@ export namespace Metrics {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return MetricsSchema.parse(await res.json());
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return MetricsSchema.parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/office.ts
+++ b/client/src/api/office.ts
@@ -1,12 +1,4 @@
-import {
-    CREATED,
-    NO_CONTENT,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { type Office as OfficeType, OfficeSchema } from '~model/office.ts';
 
@@ -30,11 +22,11 @@ export namespace Office {
             },
         });
         switch (res.status) {
-            case CREATED: return OfficeSchema.shape.id.parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.CREATED: return OfficeSchema.shape.id.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -47,12 +39,12 @@ export namespace Office {
             headers: { 'Content-Type': 'text/plain' },
         });
         switch (res.status) {
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return false;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return false;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/session.ts
+++ b/client/src/api/session.ts
@@ -1,4 +1,4 @@
-import { OK, UNAUTHORIZED, NOT_ACCEPTABLE } from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { type User, UserSchema } from '../../../model/src/user.ts';
 
@@ -15,9 +15,9 @@ export namespace Session {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case OK: return UserSchema.parse(await res.json());
-            case UNAUTHORIZED: throw new InvalidSession;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.OK: return UserSchema.parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/snapshot.ts
+++ b/client/src/api/snapshot.ts
@@ -1,11 +1,4 @@
-import {
-    CREATED,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_ACCEPTABLE,
-    CONFLICT,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import type { Office } from '~model/office.ts';
 
@@ -35,12 +28,12 @@ export namespace Snapshot {
             },
         });
         switch (res.status) {
-            case CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
-            case CONFLICT: return InsertSnapshotErrorSchema.parse(await res.json());
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
+            case StatusCodes.CONFLICT: return InsertSnapshotErrorSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/staff.ts
+++ b/client/src/api/staff.ts
@@ -1,12 +1,4 @@
-import {
-    ACCEPTED,
-    NO_CONTENT,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import type { Staff as StaffType } from '~model/staff.ts';
 
@@ -27,12 +19,12 @@ export namespace Staff {
             headers: { 'Content-Type': 'text/plain' },
         });
         switch (res.status) {
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return false;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return false;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -45,13 +37,13 @@ export namespace Staff {
             headers: { 'Content-Type': 'text/plain' },
         });
         switch (res.status) {
-            case ACCEPTED: return false;
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return null;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.ACCEPTED: return false;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,11 +1,4 @@
-import {
-    NO_CONTENT,
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    NOT_ACCEPTABLE,
-} from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import type { User as UserType } from '~model/user.ts';
 
@@ -26,12 +19,12 @@ export namespace User {
             headers: { 'Content-Type': 'text/plain' },
         });
         switch (res.status) {
-            case NO_CONTENT: return true;
-            case NOT_FOUND: return false;
-            case BAD_REQUEST: throw new InvalidInput;
-            case UNAUTHORIZED: throw new InvalidSession;
-            case FORBIDDEN: throw new InsufficientPermissions;
-            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.NO_CONTENT: return true;
+            case StatusCodes.NOT_FOUND: return false;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/vapid.ts
+++ b/client/src/api/vapid.ts
@@ -1,4 +1,4 @@
-import { OK, CREATED } from 'http-status';
+import { StatusCodes } from 'http-status-codes';
 
 import { UnexpectedStatusCode } from './error.ts';
 import { assert } from '../assert.ts';
@@ -7,7 +7,7 @@ export namespace Vapid {
     /** @returns VAPID public key of the server as raw bytes */
     export async function getVapidPublicKey(): Promise<ArrayBuffer> {
         const res = await fetch('/api/vapid', { headers: { 'Accept': 'application/octet-stream' } });
-        if (res.status === OK) return res.arrayBuffer();
+        if (res.status === StatusCodes.OK) return res.arrayBuffer();
         throw new UnexpectedStatusCode;
     }
 
@@ -16,7 +16,7 @@ export namespace Vapid {
         const auth = keys?.auth;
         assert(auth);
 
-        const p256dh = keys.p256dh;
+        const p256dh = keys?.p256dh;
         assert(p256dh);
 
         const res = await fetch('/api/vapid', {
@@ -30,7 +30,7 @@ export namespace Vapid {
             }),
         });
 
-        if (res.status === CREATED) return;
+        if (res.status === StatusCodes.CREATED) return;
         throw new UnexpectedStatusCode;
     }
 }


### PR DESCRIPTION
This shouldn't introduce any breaking changes. The dependency change is necessary for future work in the integration testing because `http-status` is more difficult to work with across server and client boundaries.