### PR TITLE
feat(client): enforced model type annotations in client

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -1,6 +1,6 @@
 import { Document } from '../../../model/src/document.ts';
-import { Invitation } from '../../../model/src/invitation.ts'
-import { Staff } from '../../../model/src/staff.ts'
+import { Invitation } from '../../../model/src/invitation.ts';
+import { Staff } from '../../../model/src/staff.ts';
 
 export enum IconColor {
     Default = 'default', 

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -1,3 +1,7 @@
+import { Document } from '../../../model/src/document.ts';
+import { Invitation } from '../../../model/src/invitation.ts'
+import { Staff } from '../../../model/src/staff.ts'
+
 export enum IconColor {
     Default = 'default', 
     Primary = 'primary',
@@ -45,19 +49,19 @@ export enum Events {
 
 export interface ContextPayload {
     ty: RowType.AcceptDocument | RowType.Inbox;
-    id: number;
+    id: Document['id'];
 }
 
 export interface InvitePayload {
     ty: RowType.Invite;
-    email: string;
-    office: number;
+    email: Invitation['email'];
+    office: Invitation['office'];
 }
 
 export interface PersonPayload {
     ty: RowType.Person;
-    id: number;
-    office: number;
+    id: Staff['user_id'];
+    office: Staff['office'];
 }
 
 export type RowEvent = ContextPayload | InvitePayload | PersonPayload;

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -5,11 +5,12 @@
     import RowTemplate from '../RowTemplate.svelte';
 
     import { ContextPayload, RowType, IconSize, Events } from '../../types.ts';
+    import { Document } from '../../../../../model/src/document.ts';
 
     export let iconSize = IconSize.Normal;
-    export let id: string;
-    export let category: number;
-    export let title: string;
+    export let id: Document['id'];
+    export let category: Document['category'];
+    export let title: Document['title'];
 
     const dispatch = createEventDispatcher();
     const rowEvent: ContextPayload = {

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -5,11 +5,13 @@
     import RowTemplate from '../RowTemplate.svelte';
 
     import { IconSize, ContextPayload, RowType, Events } from '../../types.ts';
+    import { Document } from '../../../../../model/src/document.ts';
+
 
     export let iconSize = IconSize.Normal;
-    export let id: string;
-    export let category: number;
-    export let title: string;
+    export let id: Document['id'];
+    export let category: Document['category'];
+    export let title: Document['title'];
 
     const dispatch = createEventDispatcher();
     const rowEvent: ContextPayload = {

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -5,14 +5,14 @@
     import RowTemplate from '../RowTemplate.svelte';
 
     import { IconSize, InvitePayload, RowType, Events } from '../../types.ts';
-
+    import { Invitation } from '../../../../../model/src/invitation.ts'
     export let iconSize = IconSize.Normal;
 
     // From invitation.ts
-    export let office: number;
-    export let email: string;
-    export let permission: number;
-    export let creation: string;
+    export let office: Invitation['office'];
+    export let email: Invitation['email'];
+    export let permission: Invitation['permission'];
+    export let creation: Invitation['creation'];
     
     const dispatch = createEventDispatcher();
     const rowEvent: InvitePayload = {

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -5,7 +5,7 @@
     import RowTemplate from '../RowTemplate.svelte';
 
     import { IconSize, InvitePayload, RowType, Events } from '../../types.ts';
-    import { Invitation } from '../../../../../model/src/invitation.ts'
+    import { Invitation } from '../../../../../model/src/invitation.ts';
     export let iconSize = IconSize.Normal;
 
     // From invitation.ts

--- a/client/src/components/ui/itemrow/PersonRow.svelte
+++ b/client/src/components/ui/itemrow/PersonRow.svelte
@@ -7,7 +7,6 @@
     import { PersonPayload, IconSize, Events} from '../../types.ts';
     import { User } from '../../../../../model/user.ts';
     import { Staff } from '../../../../../model/staff.ts';
-    '
     export let iconSize = IconSize.Normal;
     
     // From user.ts

--- a/client/src/components/ui/itemrow/PersonRow.svelte
+++ b/client/src/components/ui/itemrow/PersonRow.svelte
@@ -4,21 +4,22 @@
 
     import RowTemplate from '../RowTemplate.svelte';
 
-
     import { PersonPayload, IconSize, Events} from '../../types.ts';
-
+    import { User } from '../../../../../model/user.ts';
+    import { Staff } from '../../../../../model/staff.ts';
+    '
     export let iconSize = IconSize.Normal;
     
     // From user.ts
-    export let id: string;
-    export let name: string;
-    export let email: string;
-    export let picture: string;
-    export let globalPermission: number;
+    export let id: User['id'];
+    export let name: User['name'];
+    export let email: User['email'];
+    export let picture: User['picture'];
+    export let globalPermission: User['permission'];
 
     // From staff.ts
-    export let office: number;
-    export let localPermission: number;
+    export let office: Staff['office'];
+    export let localPermission: Staff['permission'];
 
     const dispatch = createEventDispatcher();
     const rowEvent: PersonPayload = {


### PR DESCRIPTION
This PR aims to use the files in `modals` as the type annotations in our client components from this point on.