### PR TITLE
feat(api): get all offices in the system

### DIFF
--- a/client/src/api/office.ts
+++ b/client/src/api/office.ts
@@ -11,6 +11,20 @@ import {
 } from './error.ts';
 
 export namespace Office {
+    export async function getAll(): Promise<OfficeType[]> {
+        const res = await fetch('/api/office', {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return OfficeSchema.array().parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
     export async function create(name: OfficeType['name']): Promise<OfficeType['id']> {
         const res = await fetch('/api/office', {
             credentials: 'same-origin',

--- a/model/src/permission.ts
+++ b/model/src/permission.ts
@@ -16,12 +16,13 @@ export enum Local {
 
 /** Represents the global permission (operator-level) bit string. */
 export enum Global {
-    CreateOffice = 1,
-    UpdateOffice = 2,
-    UpdateUser = 4,
-    CreateCategory = 8,
-    UpdateCategory = 16,
-    DeleteCategory = 32,
-    ActivateCategory = 64,
-    ViewMetrics = 128,
+    GetOffices = 1,
+    CreateOffice = 2,
+    UpdateOffice = 4,
+    UpdateUser = 8,
+    CreateCategory = 16,
+    UpdateCategory = 32,
+    DeleteCategory = 64,
+    ActivateCategory = 128,
+    ViewMetrics = 256,
 }

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -44,6 +44,7 @@ Deno.test('full OAuth flow', async t => {
     await t.step('update office information', async () => {
         assertFalse(await db.updateOffice({ id: 0, name: 'Hello' }));
         assert(await db.updateOffice({ id: office, name: 'Hello' }));
+        assertArrayIncludes(await db.getAllOffices(), [ { id: office, name: 'Hello' } ]);
     });
 
     await t.step('successfully revoke invites from the system', async () => {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -479,6 +479,12 @@ export class Database {
                 .parse(first);
     }
 
+    /** Get all offices from the system. */
+    async getAllOffices(): Promise<Office[]> {
+        const { rows } = await this.#client.queryObject`SELECT id,name FROM office`;
+        return OfficeSchema.array().parse(rows);
+    }
+
     /** Adds a new office to the system. */
     async createOffice(name: Office['name']): Promise<Office['id']> {
         const { rows: [ first, ...rest ] } = await this.#client

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -17,7 +17,7 @@ import {
 import { handleCreateDocument, handleGetInbox, handleGetPaperTrail } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation } from './api/invite.ts';
 import { handleGenerateUserSummary } from './api/metrics.ts';
-import { handleCreateOffice, handleUpdateOffice } from './api/office.ts';
+import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
 import { handleSetStaffPermissions, handleRemoveStaff } from './api/staff.ts';
@@ -36,6 +36,7 @@ export async function handleGet(pool: Pool, req: Request) {
         case '/api/document': return handleGetPaperTrail(pool, req, searchParams);
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
         case '/api/metrics/user': return handleGenerateUserSummary(pool, req);
+        case '/api/offices': return handleGetAllOffices(pool, req);
         case '/api/session': return handleGetUserFromSession(pool, req);
         case '/api/vapid': return handleVapidPublicKey();
         case '/auth/login': return handleLogin(pool, req);


### PR DESCRIPTION
This PR adds the API endpoint `GET /api/offices` (note the plural!), which fetches a list of all the offices in the system. It rejects requests without a valid session ID with sufficient permissions.

This is necessary so that we can provide a dropdown menu of offices to the dashboard whenever a staff member wishes to send a document to another office.