### PR TITLE
feat(client): implement Office Management Components

### DIFF
--- a/client/src/api/office.ts
+++ b/client/src/api/office.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type Office as OfficeType, OfficeSchema } from '~model/office.ts';
+import { type Office as OfficeType, OfficeSchema } from '../../../model/src/office.ts';
 
 import {
     InsufficientPermissions,

--- a/client/src/components/ui/TextInput.svelte
+++ b/client/src/components/ui/TextInput.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
-  import { InputType } from '../types.ts';
-  
-  export let type: InputType = InputType.Text;
-  export let placeholder = '';
-  export let disabled = false;
-  export let name: string;
-  export let isRoundedBorder = true;
-  export let label: string;
+    import { InputType } from '../types.ts';
+
+    export let type: InputType = InputType.Text;
+    export let placeholder = '';
+    export let disabled = false;
+    export let name: string;
+    export let isRoundedBorder = true;
+    export let label: string;
 </script>
 
 <label>
-  {label}
-  <input {type} {placeholder} {name} {disabled} class:round-border={isRoundedBorder} />
+    {label}
+    <input {type} {placeholder} {name} {disabled} class:round-border={isRoundedBorder} />
 </label>
 
 <style>
-  @import url('../../pages/vars.css');
+    @import url('../../pages/vars.css');
 
-  input {
-    border: var(--primary-color) 2px solid;
-    padding: var(--spacing-small) var(--spacing-normal);
-  }
+    input {
+        border: var(--primary-color) 2px solid;
+        padding: var(--spacing-small) var(--spacing-normal);
+    }
 
-  .round-border {
+    .round-border {
     border-radius: var(--border-radius);
-  }
+    }
 </style>

--- a/client/src/components/ui/TextInput.svelte
+++ b/client/src/components/ui/TextInput.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   import { InputType } from '../types.ts';
-  export let type = InputType.Primary;
+  
+  export let type: InputType = InputType.Text;
   export let placeholder = '';
+  export let disabled = false;
   export let name: string;
   export let isRoundedBorder = true;
+  export let label: string;
 </script>
 
-<label for={name}><slot></slot></label>
-<input {type} {placeholder} {name} class:round-border={isRoundedBorder} />
+<label>
+  {label}
+  <input {type} {placeholder} {name} {disabled} class:round-border={isRoundedBorder} />
+</label>
 
 <style>
   @import url('../../pages/vars.css');

--- a/client/src/components/ui/forms/EditOffice.svelte
+++ b/client/src/components/ui/forms/EditOffice.svelte
@@ -40,13 +40,11 @@
 
 <section>
     <!--TODO: Replace with dropdown selection implementation-->
-    {#if (!$officeList)}
-        No offices avaialble
+    {#each $officeList as office}
+        <p data-id={office.id} data-name={office.name}>{office.id}: {office.name}</p>
     {:else}
-        {#each $officeList as office}
-            <p data-id={office.id} data-name={office.name}>{office.id}: {office.name}</p>
-        {/each}
-    {/if}
+        No offices available
+    {/each}
 </section>
 <article>
     <form on:submit|preventDefault|stopPropagation={handleSubmit}>
@@ -61,7 +59,7 @@
             name="officename"
             label="Office Name:"
         />
-        <Button submit><Checkmark alt="Edit Office"/> Edit Office </Button>
+        <Button submit><Checkmark alt="Edit Office"/> Edit Office</Button>
     </form>
 </article>
 

--- a/client/src/components/ui/forms/EditOffice.svelte
+++ b/client/src/components/ui/forms/EditOffice.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { assert } from '../../../assert.ts';
+
+    import { Office } from '../../../api/office.ts';
+    import { InputType } from '../../types.ts';
+    import { userSession } from '../../../pages/dashboard/stores/UserStore.ts';
+    import { officeList } from '../../../pages/dashboard/stores/OfficeStore.ts';
+
+    import TextInput from '../TextInput.svelte';
+    import Button from '../Button.svelte';
+    import Checkmark from '../../icons/Checkmark.svelte';
+
+    async function handleSubmit(this: HTMLFormElement) {
+        const elOfficeId = this.elements.namedItem('officeid');
+        const elOfficeName = this.elements.namedItem('officename')
+        
+        assert(elOfficeId instanceof HTMLInputElement);
+        assert(elOfficeName instanceof HTMLInputElement);
+        assert(elOfficeId.type === 'number')
+        assert(elOfficeName.type === 'text');
+        
+        
+        if (!elOfficeId.value || !elOfficeName.value) return;
+        
+        try {
+            // Create a pseudo-office element
+            await Office.update({
+                id: elOfficeId.value,
+                name: elOfficeName.value
+            });
+            await officeList.reload?.();
+            this.reset();
+        }
+        catch (err) {
+            // TODO: No permission handler
+            alert(err);
+        }
+    }
+
+</script>
+
+<p>You are currently editing an office {$userSession.email}</p>
+
+<section>
+    <!--TODO: Replace with dropdown selection implementation-->
+    {#if (!$officeList)}
+        No offices avaialble
+    {:else}
+        {#each $officeList as office}
+            <p data-id={office.id} data-name={office.name}>{office.id}: {office.name}</p>
+        {/each}
+    {/if}
+</section>
+<article>
+    <form on:submit|preventDefault|stopPropagation={handleSubmit}>
+        <TextInput 
+            placeholder="New Office ID"
+            type = {InputType.Number}
+            name="officeid"
+            label="Office ID:"
+        />
+        <TextInput 
+            placeholder="Office Name"
+            name="officename"
+            label="Office Name:"
+        />
+        <Button submit><Checkmark alt="Edit Office"/> Edit Office </Button>
+    </form>
+</article>
+
+
+<style>
+    @import url('../../../pages/vars.css');
+    section {
+        overflow-y: scroll;
+        border: var(--spacing-tiny) solid;
+        height: 50vh;
+    }
+</style>

--- a/client/src/components/ui/forms/EditOffice.svelte
+++ b/client/src/components/ui/forms/EditOffice.svelte
@@ -19,7 +19,6 @@
         assert(elOfficeId.type === 'number')
         assert(elOfficeName.type === 'text');
         
-        
         if (!elOfficeId.value || !elOfficeName.value) return;
         
         try {
@@ -30,13 +29,11 @@
             });
             await officeList.reload?.();
             this.reset();
-        }
-        catch (err) {
+        } catch (err) {
             // TODO: No permission handler
             alert(err);
         }
     }
-
 </script>
 
 <p>You are currently editing an office {$userSession.email}</p>
@@ -67,7 +64,6 @@
         <Button submit><Checkmark alt="Edit Office"/> Edit Office </Button>
     </form>
 </article>
-
 
 <style>
     @import url('../../../pages/vars.css');

--- a/client/src/components/ui/forms/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/GlobalPermissions.svelte
@@ -35,7 +35,6 @@
             alert(err);
         }
     }
-
 </script>
 
 <h2>{$userSession.name}</h2>

--- a/client/src/components/ui/forms/NewOffice.svelte
+++ b/client/src/components/ui/forms/NewOffice.svelte
@@ -42,8 +42,9 @@
 <article>
     <form on:submit|preventDefault|stopPropagation={handleSubmit}>
         <TextInput 
-            placeholder = "New Office Name"
-            name = "officename"
+            placeholder="New Office Name"
+            name="officename"
+            label="New Office Name:"
         >
         Office Name: 
         </TextInput>

--- a/client/src/components/ui/forms/NewOffice.svelte
+++ b/client/src/components/ui/forms/NewOffice.svelte
@@ -20,8 +20,7 @@
             await Office.create(node.value);
             await officeList.reload?.();
             this.reset();
-        }
-        catch (err) {
+        } catch (err) {
             // TODO: No permission handler
             alert(err);
         }
@@ -31,13 +30,11 @@
 <p>You are currently adding an office as {$userSession.email}</p>
 
 <section>
-    {#if (!$officeList)}
-        No offices avaialble
+    {#each $officeList as office}
+        <p>{office.id}: {office.name}</p>
     {:else}
-        {#each $officeList as office}
-            <p>{office.id}: {office.name}</p>
-        {/each}
-    {/if}
+        No offices available
+    {/each}
 </section>
 <article>
     <form on:submit|preventDefault|stopPropagation={handleSubmit}>
@@ -45,13 +42,10 @@
             placeholder="New Office Name"
             name="officename"
             label="New Office Name:"
-        >
-        Office Name: 
-        </TextInput>
-        <Button submit><Checkmark alt="Create New Office"/> New Office </Button>
+        />
+        <Button submit><Checkmark alt="Create New Office"/> New Office</Button>
     </form>
 </article>
-
 
 <style>
     @import url('../../../pages/vars.css');

--- a/client/src/components/ui/forms/NewOffice.svelte
+++ b/client/src/components/ui/forms/NewOffice.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { assert } from '../../../assert.ts';
+
+    import { Office } from '../../../api/office.ts';
+    import { userSession } from '../../../pages/dashboard/stores/UserStore.ts';
+    import { officeList } from '../../../pages/dashboard/stores/OfficeStore.ts';
+
+    import TextInput from '../TextInput.svelte';
+    import Button from '../Button.svelte';
+    import Checkmark from '../../icons/Checkmark.svelte';
+
+    async function handleSubmit(this: HTMLFormElement) {
+        const node = this.elements.namedItem('officename');
+        assert(node instanceof HTMLInputElement);
+        assert(node.type === 'text');
+        
+        if (!node.value) return;
+        
+        try {
+            await Office.create(node.value);
+            await officeList.reload?.();
+            this.reset();
+        }
+        catch (err) {
+            // TODO: No permission handler
+            alert(err);
+        }
+    }
+</script>
+
+<p>You are currently adding an office as {$userSession.email}</p>
+
+<section>
+    {#if (!$officeList)}
+        No offices avaialble
+    {:else}
+        {#each $officeList as office}
+            <p>{office.id}: {office.name}</p>
+        {/each}
+    {/if}
+</section>
+<article>
+    <form on:submit|preventDefault|stopPropagation={handleSubmit}>
+        <TextInput 
+            placeholder = "New Office Name"
+            name = "officename"
+        >
+        Office Name: 
+        </TextInput>
+        <Button submit><Checkmark alt="Create New Office"/> New Office </Button>
+    </form>
+</article>
+
+
+<style>
+    @import url('../../../pages/vars.css');
+    section {
+        overflow-y: scroll;
+        border: var(--spacing-tiny) solid;
+        height: 50vh;
+    }
+</style>

--- a/client/src/pages/Home.svelte
+++ b/client/src/pages/Home.svelte
@@ -20,12 +20,12 @@
             <img src={placeholderSrc} alt="DocTrack Logo" />
             <h3>DocTrack: Document Tracking System</h3>
             <a href="/auth/login">
-                <Button type={ButtonType.Primary}><Google />Log in with University of the Philippines Mail</Button>
+                <Button type={ButtonType.Primary}><Google alt="Log in with UP Mail"/>Log in with University of the Philippines Mail</Button>
             </a>
             <div class="search-container">
-                <TextInput type={InputType.Primary} placeholder="Enter tracking number here..." />
-                <Button type={ButtonType.Primary}><Camera /></Button>
-                <Button type={ButtonType.Primary}><Search /></Button>
+                <TextInput type={InputType.Primary} placeholder="Enter tracking number here..." label="Tracking Number:"/>
+                <Button type={ButtonType.Primary}><Camera alt="Take/select an image." /></Button>
+                <Button type={ButtonType.Primary}><Search alt="Search specified tracking number. "/></Button>
             </div>
         </div>
     {/await}

--- a/client/src/pages/dashboard/stores/OfficeStore.ts
+++ b/client/src/pages/dashboard/stores/OfficeStore.ts
@@ -1,0 +1,13 @@
+// HACK: IntelliSense doesn't seem to be playing nice unless we do this.
+import type { Loadable } from '@square/svelte-store/lib/async-stores/types.js';
+import { asyncReadable } from '@square/svelte-store/lib/async-stores';
+
+import type { Office as OfficeModel } from './../../../../model/src/office.ts';
+
+import { Office } from '../../../api/office.ts'
+
+export const officeList: Loadable<OfficeModel[]> = asyncReadable (
+    null,
+    Office.getAll,
+    { reloadable: true}
+);

--- a/client/src/pages/dashboard/stores/OfficeStore.ts
+++ b/client/src/pages/dashboard/stores/OfficeStore.ts
@@ -7,7 +7,7 @@ import type { Office as OfficeModel } from './../../../../model/src/office.ts';
 import { Office } from '../../../api/office.ts'
 
 export const officeList: Loadable<OfficeModel[]> = asyncReadable (
-    null,
+    [],
     Office.getAll,
     { reloadable: true}
 );

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -8,8 +8,12 @@
     import Select from '../../../components/ui/Select.svelte';
     import Button from '../../../components/ui/Button.svelte';
     import GlobalPermissions from '../../../components/ui/forms/GlobalPermissions.svelte';
+    import NewOffice from '../../../components/ui/forms/NewOffice.svelte';
+    import EditOffice from '../../../components/ui/forms/EditOffice.svelte'
 
     let showContextMenu = false;
+    let showCreateOffice = false;
+    let showEditOffice = false;
     let currentContext: RowEvent | null = null;
     let currentlySelected = '';
     let showPermission = false;
@@ -23,11 +27,27 @@
 <h1>Sandbox</h1>
 
 <Button on:click={() => showPermission = true}>
-    Click me to Edit Global Permissions
+    Edit Global Permissions
+</Button>
+
+<Button on:click={() => showCreateOffice = true}>
+    Create an Office
+</Button>
+
+<Button on:click={() => showEditOffice = true}>
+    Edit an Office
 </Button>
 
 <Modal title="Edit Global Permissions" bind:showModal={showPermission}>
     <GlobalPermissions />
+</Modal>
+
+<Modal title="Create New Office" bind:showModal={showCreateOffice}>
+    <NewOffice/>
+</Modal>
+
+<Modal title="Edit Office" bind:showModal={showEditOffice}>
+    <EditOffice/>
 </Modal>
 
 <Select


### PR DESCRIPTION
This PR aims to add add Office Management Components (dialogs). 
NOTE: The selection method in `EditOffice.svelte` will be changed to a dropdown when the appropriate PR is pushed.
![opera_3FCGrKJ6pq](https://user-images.githubusercontent.com/22850026/230034343-235424d0-600a-4d2f-9c95-6bec5de8eb10.gif)
