### PR TITLE
feat(api): expand session getter so that it includes local permissions

### DIFF
--- a/client/src/api/session.ts
+++ b/client/src/api/session.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type User, UserSchema } from '../../../model/src/user.ts';
+import { type FullSession, FullSessionSchema } from '../../../model/src/api.ts';
 
 import {
     InvalidSession,
@@ -9,13 +9,13 @@ import {
 } from './error.ts';
 
 export namespace Session {
-    export async function getUser(): Promise<User> {
+    export async function getUser(): Promise<FullSession> {
         const res = await fetch('/api/session', {
             credentials: 'same-origin',
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case StatusCodes.OK: return UserSchema.parse(await res.json());
+            case StatusCodes.OK: return FullSessionSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -70,10 +70,7 @@ export type Metrics = z.infer<typeof MetricsSchema>;
 export const FullSessionSchema = UserSchema
     .omit({ permission: true })
     .extend({
-        global_perms: z.string().transform(bits => parseInt(bits, 2)).pipe(UserSchema.shape.permission),
-        local_perms: z.record(
-            z.string().transform(oid => parseInt(oid, 10)).pipe(OfficeSchema.shape.id),
-            z.string().transform(bits => parseInt(bits, 2)).pipe(StaffSchema.shape.permission),
-        ),
+        global_perms: UserSchema.shape.permission,
+        local_perms: z.record(z.coerce.number().pipe(OfficeSchema.shape.id), StaffSchema.shape.permission),
     });
 export type FullSession = z.infer<typeof FullSessionSchema>;

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -4,7 +4,9 @@ import { BarcodeSchema } from './barcode.ts';
 import { BatchSchema } from './batch.ts';
 import { CategorySchema } from './category.ts';
 import { DocumentSchema } from './document.ts';
+import { OfficeSchema } from './office.ts';
 import { SnapshotSchema, StatusSchema } from './snapshot.ts';
+import { StaffSchema } from './staff.ts';
 import { UserSchema } from './user.ts';
 
 export const MinBatchSchema = z.object({
@@ -64,3 +66,14 @@ export type Summary = z.infer<typeof SummarySchema>;
 
 export const MetricsSchema = z.record(StatusSchema, SummarySchema.shape.amount);
 export type Metrics = z.infer<typeof MetricsSchema>;
+
+export const FullSessionSchema = UserSchema
+    .omit({ permission: true })
+    .extend({
+        global_perms: z.string().transform(bits => parseInt(bits, 2)).pipe(UserSchema.shape.permission),
+        local_perms: z.record(
+            z.string().transform(oid => parseInt(oid, 10)).pipe(OfficeSchema.shape.id),
+            z.string().transform(bits => parseInt(bits, 2)).pipe(StaffSchema.shape.permission),
+        ),
+    });
+export type FullSession = z.infer<typeof FullSessionSchema>;

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -195,6 +195,21 @@ Deno.test('full OAuth flow', async t => {
         });
     });
 
+    await t.step('getting full user session information', async () => {
+        // Non-existent session
+        assertStrictEquals(await db.getFullSessionInfo(crypto.randomUUID()), null);
+
+        // Existing session
+        const info = await db.getFullSessionInfo(id);
+        assert(info !== null);
+        assertEquals(info.id, USER.id);
+        assertEquals(info.name, USER.name);
+        assertEquals(info.email, USER.email);
+        assertEquals(info.picture, USER.picture);
+        assertStrictEquals(info.global_perms, 0b111)
+        assertStrictEquals(info.local_perms[office], 0b011);
+    });
+
     await t.step('category tests', async () => {
         assertStrictEquals(await db.activateCategory(0), null);
         assertStrictEquals(await db.deleteCategory(0), null);

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -43,6 +43,12 @@ type InvalidatedSession = {
 
 const DeprecationSchema = z.object({ result: z.boolean().nullable() });
 
+const Bitstring = z.string().transform(bits => parseInt(bits, 2));
+const PostgresFullSession = FullSessionSchema.extend({
+    global_perms: Bitstring.pipe(FullSessionSchema.shape.global_perms),
+    local_perms: z.record(z.string().transform(num => parseInt(num, 10)), Bitstring).pipe(FullSessionSchema.shape.local_perms),
+});
+
 export class Database {
     #client: PoolClient;
 
@@ -494,7 +500,7 @@ export class Database {
         assertStrictEquals(rest.length, 0);
         return first === undefined
             ? null
-            : FullSessionSchema.parse(first);
+            : PostgresFullSession.parse(first);
     }
 
     /** Get all offices from the system. */

--- a/server/src/routes/api/session.ts
+++ b/server/src/routes/api/session.ts
@@ -31,7 +31,7 @@ export async function handleGetUserFromSession(pool: Pool, req: Request) {
 
     const db = await Database.fromPool(pool);
     try {
-        const user = await db.getUserFromSession(sid);
+        const user = await db.getFullSessionInfo(sid);
         if (user === null) {
             error(`[Session] Invalid session ${sid}`);
             return new Response(null, { status: Status.Unauthorized });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -166,7 +166,10 @@ Deno.test('full API integration test', async t => {
     await t.step('Session API', async () => {
         const session = await Session.getUser();
         assertEquals(session, {
-            ...user,
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            picture: user.picture,
             local_perms: { [oid]: (Local.ViewMetrics << 1) - 1 },
             global_perms: user.permission,
         });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -122,11 +122,6 @@ Deno.test('full API integration test', async t => {
         });
     });
 
-    await t.step('Session API', async () => {
-        const session = await Session.getUser();
-        assertEquals(session, user);
-    });
-
     await t.step('User API', async () =>
         assert(await User.setPermission({
             id: user.id,
@@ -167,6 +162,15 @@ Deno.test('full API integration test', async t => {
             permission: (Local.ViewMetrics << 1) - 1,
         }))
     );
+
+    await t.step('Session API', async () => {
+        const session = await Session.getUser();
+        assertEquals(session, {
+            ...user,
+            local_perms: { [oid]: (Local.ViewMetrics << 1) - 1 },
+            global_perms: user.permission,
+        });
+    });
 
     const origCategories = await Category.getAllActive();
     await t.step('Category API - creation/deletion', async () => {


### PR DESCRIPTION
This PR expands the `GET /api/session` endpoint so that it also returns a dictionary of local permissions (with respect to their respective office IDs). There should be no breaking changes on the client side because we are only adding new fields.