### PR TITLE
feat(server): treat office creators as superuser by default

### DIFF
--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -4,6 +4,7 @@ import {
     assertEquals,
     assertFalse,
     assertInstanceOf,
+    assertNotStrictEquals,
     assertStrictEquals,
     equal,
 } from 'asserts';
@@ -229,6 +230,9 @@ Deno.test('full OAuth flow', async t => {
         assertStrictEquals(await db.activateCategory(id), null);
         assertStrictEquals(await db.deleteCategory(id), null);
     });
+
+    await t.step('office creation with superuser', async () =>
+        assertNotStrictEquals(await db.createOfficeWithSuperuser(USER.id, 'Cool Office'), 0));
 
     const { id: batch, codes } = await db.generateBatch({ office, generator: USER.id });
     await t.step('batch generation', () => {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -529,7 +529,8 @@ export class Database {
         // Add first superuser of the office
         const { id } = OfficeSchema.pick({ id: true }).parse(first);
         const { rowCount } = await transaction
-            .queryArray`INSERT INTO staff (user_id,office,permission) VALUES (${admin},${id},4095::bit(11)::LocalPermission)`;
+            .queryArray`INSERT INTO staff (user_id,office,permission) VALUES (${admin},${id},4095::bit(12)::LocalPermission)`;
+
         assertStrictEquals(rowCount, 1);
 
         await transaction.commit();

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -529,7 +529,7 @@ export class Database {
         // Add first superuser of the office
         const { id } = OfficeSchema.pick({ id: true }).parse(first);
         const { rowCount } = await transaction
-            .queryArray`INSERT INTO staff (user_id,office,permission) VALUES (${admin},${id},4095::LocalPermission)`;
+            .queryArray`INSERT INTO staff (user_id,office,permission) VALUES (${admin},${id},4095::bit(11)::LocalPermission)`;
         assertStrictEquals(rowCount, 1);
 
         await transaction.commit();

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -517,10 +517,8 @@ export class Database {
         return OfficeSchema.pick({ id: true }).parse(first).id;
     }
 
-    /** Adds a new office to the system. */
+    /** Adds a new office to the system. Assumes that the `admin` is a valid user ID. */
     async createOfficeWithSuperuser(admin: User['id'], name: Office['name']): Promise<Office['id']> {
-        // TODO: add tests
-
         // Create new office
         const transaction = this.#client.createTransaction('office_superuser');
         await transaction.begin();

--- a/server/src/routes/api/office.ts
+++ b/server/src/routes/api/office.ts
@@ -111,9 +111,9 @@ export async function handleCreateOffice(pool: Pool, req: Request) {
             return new Response(null, { status: Status.Forbidden });
         }
 
-        const office = await db.createOffice(name);
-        info(`[Office] User ${operator.id} ${operator.name} <${operator.email}> created new office ${office} "${name}"`);
-        return new Response(office.toString(), {
+        const oid = await db.createOfficeWithSuperuser(operator.id, name);
+        info(`[Office] User ${operator.id} ${operator.name} <${operator.email}> created new office ${oid} "${name}"`);
+        return new Response(oid.toString(), {
             headers: { 'Content-Type': 'application/json' },
             status: Status.Created,
         });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -22,7 +22,7 @@ import { Staff } from '~client/api/staff.ts';
 import { User } from '~client/api/user.ts';
 import { Vapid } from '~client/api/vapid.ts';
 
-import { Global, Local } from '~model/permission.ts';
+import { Local } from '~model/permission.ts';
 import { Status } from '~model/snapshot.ts';
 
 import { Database } from '~server/database.ts';
@@ -44,7 +44,7 @@ async function setup(pool: Pool) {
         const email = `${randomEmail}@up.edu.ph`;
         const creation = await db.upsertInvitation({
             office: oid,
-            permission: (Local.ViewInbox << 1) - 1,
+            permission: 4095,
             email,
         });
         assertNotStrictEquals(creation, null);
@@ -54,7 +54,7 @@ async function setup(pool: Pool) {
             id: crypto.randomUUID(),
             name: 'Hello World',
             picture: 'https://doctrack.app/profile/user.png',
-            permission: (Global.ViewMetrics << 1) - 1,
+            permission: 511,
             email,
         };
 
@@ -159,7 +159,7 @@ Deno.test('full API integration test', async t => {
         assert(await Staff.setPermission({
             office: oid,
             user_id: user.id,
-            permission: (Local.ViewInbox << 1) - 1,
+            permission: 4095,
         }))
     );
 
@@ -171,8 +171,8 @@ Deno.test('full API integration test', async t => {
             email: user.email,
             picture: user.picture,
             local_perms: {
-                [oid]: (Local.ViewInbox << 1) - 1,
-                [otherOid]: (Local.ViewInbox << 1) - 1,
+                [oid]: 4095,
+                [otherOid]: 4095,
             },
             global_perms: user.permission,
         });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -159,7 +159,7 @@ Deno.test('full API integration test', async t => {
         assert(await Staff.setPermission({
             office: oid,
             user_id: user.id,
-            permission: (Local.ViewMetrics << 1) - 1,
+            permission: (Local.ViewInbox << 1) - 1,
         }))
     );
 
@@ -171,8 +171,8 @@ Deno.test('full API integration test', async t => {
             email: user.email,
             picture: user.picture,
             local_perms: {
-                [oid]: (Local.ViewMetrics << 1) - 1,
-                [otherOid]: (Local.ViewMetrics << 1) - 1,
+                [oid]: (Local.ViewInbox << 1) - 1,
+                [otherOid]: (Local.ViewInbox << 1) - 1,
             },
             global_perms: user.permission,
         });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -170,7 +170,10 @@ Deno.test('full API integration test', async t => {
             name: user.name,
             email: user.email,
             picture: user.picture,
-            local_perms: { [oid]: (Local.ViewMetrics << 1) - 1 },
+            local_perms: {
+                [oid]: (Local.ViewMetrics << 1) - 1,
+                [otherOid]: (Local.ViewMetrics << 1) - 1,
+            },
             global_perms: user.permission,
         });
     });


### PR DESCRIPTION
Currently, it is impossible to set a user's local permissions because there was no superuser that set their permissions to begin with (i.e., via the Invite API). This PR addresses this by treating the creator of offices as the respective superusers—similar to how Discord treats server owners as superusers.