### PR TITLE
feat(client): add LocalPermissions form component

### DIFF
--- a/client/src/components/ui/Button.svelte
+++ b/client/src/components/ui/Button.svelte
@@ -5,7 +5,7 @@
   export let disabled = false;
 </script>
 
-  <button type={submit ? "submit" : "button"} class={type} {disabled} on:click>
+<button type={submit ? "submit" : "button"} class={type} {disabled} on:click>
     <slot>{type}</slot>
 </button>
 

--- a/client/src/components/ui/Button.svelte
+++ b/client/src/components/ui/Button.svelte
@@ -2,9 +2,10 @@
   import { ButtonType } from '../types.ts';
   export let type: ButtonType = ButtonType.Primary;
   export let submit = false;
+  export let disabled = false;
 </script>
 
-<button type={submit ? "submit" : "button"} class={type} on:click>
+  <button type={submit ? "submit" : "button"} class={type} {disabled} on:click>
     <slot>{type}</slot>
 </button>
 

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -19,7 +19,7 @@
         try {
             await Office.create(node.value);
             await officeList.reload?.();
-            await userSession.reload?.(); //reload to get superuser
+            await userSession.reload?.(); // Reload to get superuser
             this.reset();
         } catch (err) {
             // TODO: No permission handler

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -19,6 +19,7 @@
         try {
             await Office.create(node.value);
             await officeList.reload?.();
+            await userSession.reload?.(); //reload to get superuser
             this.reset();
         } catch (err) {
             // TODO: No permission handler

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -6,7 +6,6 @@
     import { Global } from '../../../../../../model/src/permission.ts';
     import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
 
-    import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -41,9 +41,6 @@
     }
 </script>
 
-<h2>{user.name}</h2>
-<p>{user.email}: {user.id}</p>
-<p>current(server side): {user.permission}</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <p>User ID: {user.id}</p>
     <label>

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -43,7 +43,6 @@
     }
 </script>
 
-<p> You are currently editing the user {user.name}: {user.email} on office {officeNo}</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <label>
         <input

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -5,15 +5,14 @@
     import type { User as UserModel } from '../../../../../../model/src/user.ts';
     import { Local } from '../../../../../../model/src/permission.ts';
     import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
-
-    import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 
     export let user: UserModel;
     export let officeNo: number;
-
-    let permission = user.permission; //pass permission here as local permission
+    let permission: UserModel['permission']; //pass permission here as local permission
+    
+    $: permission = user.permission;
 
     async function handleSubmit(this: HTMLFormElement) { 
         // Recompute permissions before submitting
@@ -47,7 +46,7 @@
     }
 </script>
 
-<p> You are currently editing {user.name}: {user.email} on office {officeNo}</p>
+<p> You are currently editing the user {user.name}: {user.email} on office {officeNo}</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <label>
         <input
@@ -139,15 +138,6 @@
             checked={(permission & Local.InsertSnapshot) === Local.InsertSnapshot}
         />
         Insert Snapshot
-    </label>
-    <label>
-        <input
-            type="checkbox"
-            name="perms"
-            value={Local.ViewMetrics}
-            checked={(permission & Local.ViewMetrics) === Local.ViewMetrics}
-        />
-        Revoke Invite
     </label>
     <label>
         <input

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -10,7 +10,7 @@
 
     export let user: UserModel;
     export let officeNo: number;
-    let permission: UserModel['permission']; //pass permission here as local permission
+    let permission: UserModel['permission']; // Pass permission here as local permission
     
     $: permission = user.permission;
 
@@ -37,7 +37,7 @@
                 permission: permsVal,
             });
 
-            //might be editing own session, might be not, reload anyway
+            // Might be editing own session, might be not, reload anyway
             await userSession.reload?.();
         } catch (err) {
             // TODO: No permission handler

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -10,9 +10,6 @@
 
     export let user: UserModel;
     export let officeNo: number;
-    let permission: UserModel['permission']; // Pass permission here as local permission
-    
-    $: permission = user.permission;
 
     async function handleSubmit(this: HTMLFormElement) { 
         // Recompute permissions before submitting
@@ -27,7 +24,7 @@
         }
 
         // No point in handling no-changes.
-        if (permission === permsVal) return;
+        if (user.permission === permsVal) return;
  
         try {
             // Rebuild pseudo-user object
@@ -53,7 +50,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={(permission & Local.AddStaff) === Local.AddStaff}
+            checked={(user.permission & Local.AddStaff) === Local.AddStaff}
         />
         Add Staff
     </label>
@@ -62,7 +59,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={(permission & Local.RemoveStaff) === Local.RemoveStaff}
+            checked={(user.permission & Local.RemoveStaff) === Local.RemoveStaff}
         />
         Remove Staff
     </label>
@@ -71,7 +68,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={(permission & Local.UpdateStaff) === Local.UpdateStaff}
+            checked={(user.permission & Local.UpdateStaff) === Local.UpdateStaff}
         />
         Update Staff
     </label>
@@ -80,7 +77,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={(permission & Local.AddInvite) === Local.AddInvite}
+            checked={(user.permission & Local.AddInvite) === Local.AddInvite}
         />
         Add Invite
     </label>
@@ -89,7 +86,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={(permission & Local.RevokeInvite) === Local.RevokeInvite}
+            checked={(user.permission & Local.RevokeInvite) === Local.RevokeInvite}
         />
         Revoke Invite
     </label>
@@ -98,7 +95,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={(permission & Local.ViewBatch) === Local.ViewBatch}
+            checked={(user.permission & Local.ViewBatch) === Local.ViewBatch}
         />
         View Batch
     </label>
@@ -107,7 +104,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={(permission & Local.GenerateBatch) === Local.GenerateBatch}
+            checked={(user.permission & Local.GenerateBatch) === Local.GenerateBatch}
         />
         Generate Batch
     </label>
@@ -116,7 +113,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={(permission & Local.InvalidateBatch) === Local.InvalidateBatch}
+            checked={(user.permission & Local.InvalidateBatch) === Local.InvalidateBatch}
         />
         Invalidate Batch
     </label>
@@ -125,7 +122,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={(permission & Local.CreateDocument) === Local.CreateDocument}
+            checked={(user.permission & Local.CreateDocument) === Local.CreateDocument}
         />
         Create Document
     </label>
@@ -134,7 +131,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={(permission & Local.InsertSnapshot) === Local.InsertSnapshot}
+            checked={(user.permission & Local.InsertSnapshot) === Local.InsertSnapshot}
         />
         Insert Snapshot
     </label>
@@ -143,7 +140,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={(permission & Local.ViewMetrics) === Local.ViewMetrics}
+            checked={(user.permission & Local.ViewMetrics) === Local.ViewMetrics}
         />
         View Metrics
     </label>
@@ -152,7 +149,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={(permission & Local.ViewInbox) === Local.ViewInbox}
+            checked={(user.permission & Local.ViewInbox) === Local.ViewInbox}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -9,7 +9,7 @@
     import Edit from '../../../icons/Edit.svelte';
 
     export let user: UserModel;
-    export let officeNo: number;
+    export let office: number;
 
     async function handleSubmit(this: HTMLFormElement) { 
         // Recompute permissions before submitting
@@ -29,7 +29,7 @@
         try {
             // Rebuild pseudo-user object
             await Staff.setPermission({
-                office: officeNo,
+                office,
                 user_id: user.id, 
                 permission: permsVal,
             });

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -120,7 +120,6 @@
         />
         Invalidate Batch
     </label>
-    
     <label>
         <input
             type="checkbox"

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+    import { assert } from '../../../../assert.ts';
+
+    import { Staff } from '../../../../api/staff.ts';
+    import type { User as UserModel } from '../../../../../../model/src/user.ts';
+    import { Local } from '../../../../../../model/src/permission.ts';
+    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
+
+    import TextInput from '../../TextInput.svelte';
+    import Button from '../../Button.svelte';
+    import Edit from '../../../icons/Edit.svelte';
+
+    export let user: UserModel;
+    export let officeNo: number;
+
+    let permission = user.permission; //pass permission here as local permission
+
+    async function handleSubmit(this: HTMLFormElement) { 
+        // Recompute permissions before submitting
+        const nodes = this.elements.namedItem('perms');
+        assert(nodes instanceof RadioNodeList);
+
+        let permsVal = 0;
+        for (const node of nodes) {
+            assert(node instanceof HTMLInputElement);
+            assert(node.type === 'checkbox');
+            if (node.checked) permsVal |= parseInt(node.value, 10);
+        }
+
+        // No point in handling no-changes.
+        if (permission === permsVal) return;
+ 
+        try {
+            // Rebuild pseudo-user object
+            await Staff.setPermission({
+                office: officeNo,
+                user_id: user.id, 
+                permission: permsVal,
+            });
+
+            //might be editing own session, might be not, reload anyway
+            await userSession.reload?.();
+        } catch (err) {
+            // TODO: No permission handler
+            alert(err);
+        }
+    }
+</script>
+
+<p> You are currently editing {user.name}: {user.email} on office {officeNo}</p>
+<form on:submit|preventDefault|stopPropagation={handleSubmit}>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.AddStaff}
+            checked={(permission & Local.AddStaff) === Local.AddStaff}
+        />
+        Add Staff
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.RemoveStaff}
+            checked={(permission & Local.RemoveStaff) === Local.RemoveStaff}
+        />
+        Remove Staff
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.UpdateStaff}
+            checked={(permission & Local.UpdateStaff) === Local.UpdateStaff}
+        />
+        Update Staff
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.AddInvite}
+            checked={(permission & Local.AddInvite) === Local.AddInvite}
+        />
+        Add Invite
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.RevokeInvite}
+            checked={(permission & Local.RevokeInvite) === Local.RevokeInvite}
+        />
+        Revoke Invite
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.ViewBatch}
+            checked={(permission & Local.ViewBatch) === Local.ViewBatch}
+        />
+        View Batch
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.GenerateBatch}
+            checked={(permission & Local.GenerateBatch) === Local.GenerateBatch}
+        />
+        Generate Batch
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.InvalidateBatch}
+            checked={(permission & Local.InvalidateBatch) === Local.InvalidateBatch}
+        />
+        Invalidate Batch
+    </label>
+    
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.CreateDocument}
+            checked={(permission & Local.CreateDocument) === Local.CreateDocument}
+        />
+        Create Document
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.InsertSnapshot}
+            checked={(permission & Local.InsertSnapshot) === Local.InsertSnapshot}
+        />
+        Insert Snapshot
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.ViewMetrics}
+            checked={(permission & Local.ViewMetrics) === Local.ViewMetrics}
+        />
+        Revoke Invite
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.ViewMetrics}
+            checked={(permission & Local.ViewMetrics) === Local.ViewMetrics}
+        />
+        View Metrics
+    </label>
+    <label>
+        <input
+            type="checkbox"
+            name="perms"
+            value={Local.ViewInbox}
+            checked={(permission & Local.ViewInbox) === Local.ViewInbox}
+        />
+        View Inbox
+    </label>
+    <Button submit><Edit alt="Modify Staff" /> Modify Staff</Button>
+</form>
+
+<style>
+    form {
+        display: flex;
+        flex-direction: column;
+    }
+</style>

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -53,12 +53,11 @@
     Select an Office: <OfficeSelect bind:oid={selectedOffice} offices={$officeList}/>
     <br>
     {#if selectedOffice !== null}
-        
         {#if $userSession.local_perms[selectedOffice] !== undefined }
-        <LocalPermissions user={{
-            ...$userSession,
-            permission: $userSession.local_perms[selectedOffice]
-        }} officeNo={selectedOffice} />
+            <LocalPermissions user={{
+                ...$userSession,
+                permission: $userSession.local_perms[selectedOffice]!,
+            }} office={selectedOffice} />
         {:else}
             Current user is not a staff of the selected office.
         {/if}

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -5,7 +5,6 @@
     import InboxRow from '../../../components/ui/itemrow/InboxRow.svelte'
     import InboxContext from '../../../components/ui/contextdrawer/InboxContext.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
-    import Select from '../../../components/ui/Select.svelte';
     import Button from '../../../components/ui/Button.svelte';
 
     import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -55,7 +55,7 @@
         {#if $userSession.local_perms[selectedOffice] !== undefined }
             <LocalPermissions user={{
                 ...$userSession,
-                permission: $userSession.local_perms[selectedOffice]!,
+                permission: $userSession.local_perms[selectedOffice],
             }} office={selectedOffice} />
         {:else}
             Current user is not a staff of the selected office.

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -12,13 +12,18 @@
     import NewOffice from '../../../components/ui/forms/office/NewOffice.svelte';
     import EditOffice from '../../../components/ui/forms/office/EditOffice.svelte'
     import { userSession } from '../stores/UserStore.ts';
+    import { officeList } from '../stores/OfficeStore.ts';
+    import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
+    import OfficeSelect from '../../../components/ui/OfficeSelect.svelte';
 
     let showContextMenu = false;
     let showCreateOffice = false;
     let showEditOffice = false;
+    let showLocalPermission = false;
     let currentContext: RowEvent | null = null;
     let currentlySelected = '';
     let showPermission = false;
+    let selectedOffice: number | null = null;
 
     function overflowClickHandler(e: CustomEvent) {
         if (!e.detail) return;
@@ -40,6 +45,25 @@
     Edit an Office
 </Button>
 
+<Button on:click={() => showLocalPermission = true} disabled={$officeList.length === 0}>
+    Edit Local Permission
+</Button>
+
+<Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
+    Select an Office: <OfficeSelect bind:oid={selectedOffice} offices={$officeList}/>
+    <br>
+    {#if selectedOffice !== null}
+        
+        {#if $userSession.local_perms[selectedOffice] !== undefined }
+        <LocalPermissions user={{
+            ...$userSession,
+            permission: $userSession.local_perms[selectedOffice]
+        }} officeNo={selectedOffice} />
+        {:else}
+            Current user is not a staff of the selected office.
+        {/if}
+    {/if}
+</Modal>
 <Modal title="Edit Global Permissions" bind:showModal={showPermission}>
     <GlobalPermissions user={{
         ...$userSession,
@@ -55,10 +79,6 @@
     <EditOffice/>
 </Modal>
 
-<Select
-    bind:value={currentlySelected}
-    options={[ 'Test Office 1', 'Test Office 2', 'Test Office 3' ]}
-/>
 <p>Currently selected: {currentlySelected}</p>
 <div>
     {#each documentTest as doc}


### PR DESCRIPTION
This PR aims to add the LocalPermissions form component. Form is user agnostic and does not rely on the `$userSession` store.
Blocked by requisite PR #49.
![opera_Emdy6xzKzB](https://user-images.githubusercontent.com/22850026/230526580-57741129-6787-45e0-9aba-59c16fa0766a.gif)
