### PR TITLE
refactor(server): prefer dictionaries over arrays of offices

### DIFF
--- a/client/src/api/office.ts
+++ b/client/src/api/office.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
+import { type AllOffices, AllOfficesSchema } from '../../../model/src/api.ts';
 import { type Office as OfficeType, OfficeSchema } from '../../../model/src/office.ts';
 
 import {
@@ -11,13 +12,13 @@ import {
 } from './error.ts';
 
 export namespace Office {
-    export async function getAll(): Promise<OfficeType[]> {
+    export async function getAll(): Promise<AllOffices> {
         const res = await fetch('/api/offices', {
             credentials: 'same-origin',
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case StatusCodes.OK: return OfficeSchema.array().parse(await res.json());
+            case StatusCodes.OK: return AllOfficesSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;

--- a/client/src/components/ui/OfficeSelect.svelte
+++ b/client/src/components/ui/OfficeSelect.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-    import type { Office } from '../../../../model/src/office.ts';
-    export let offices: Office[];
+    import type { AllOffices } from '../../../../model/src/api.ts';
+    export let offices: AllOffices;
     export let oid: number | null = null;
 </script>
 
 <select required bind:value={oid}>
-    {#each offices as office (office.id)}
-        <option value={office.id}>{office.name}</option>
+    {#each Object.entries(offices) as [id, office] (id)}
+        <option value={id}>{office}</option>
     {/each}
 </select>
 

--- a/client/src/components/ui/forms/office/EditOffice.svelte
+++ b/client/src/components/ui/forms/office/EditOffice.svelte
@@ -5,7 +5,7 @@
 
     import { Office } from '../../../../api/office.ts';
     import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
-    import { officeList } from '../../../../pages/dashboard/stores/OfficeStore.ts';
+    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
 
     import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
@@ -16,8 +16,8 @@
     let currName: OfficeModel['name'] | null = null;
 
     // eslint-disable-next-line no-extra-parens
-    $: currName = $officeList.find(office => office.id === currId)?.name ?? null;
-    
+    $: currName = currId === null ? null : $allOffices[currId] ?? null;
+
     async function handleSubmit(this: HTMLFormElement) {
         const input = this.elements.namedItem('officename');
         assert(input instanceof HTMLInputElement);
@@ -33,7 +33,7 @@
                 id: currId,
                 name: input.value,
             });
-            await officeList.reload?.();
+            await allOffices.reload?.();
 
             // eslint-disable-next-line require-atomic-updates
             currId = null;
@@ -50,11 +50,11 @@
 
 <p>You are currently editing an office as {$userSession?.email}</p>
 <article>
-    {#if $officeList.length === 0}
+    {#if Object.getOwnPropertyNames($allOffices).length === 0}
         No offices to edit.
     {:else}
         <form on:submit|preventDefault|stopPropagation={handleSubmit}>   
-            <OfficeSelect bind:oid={currId} offices={$officeList} />
+            <OfficeSelect bind:oid={currId} offices={$allOffices} />
             <br />
             {#if typeof currId === 'number'}
                 <p>Office ID: {currId}</p>

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -3,7 +3,7 @@
 
     import { Office } from '../../../../api/office.ts';
     import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
-    import { officeList } from '../../../../pages/dashboard/stores/OfficeStore.ts';
+    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
 
     import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
@@ -18,7 +18,7 @@
     
         try {
             await Office.create(node.value);
-            await officeList.reload?.();
+            await allOffices.reload?.();
             await userSession.reload?.(); // Reload to get superuser
             this.reset();
         } catch (err) {
@@ -31,8 +31,8 @@
 <p>You are currently adding an office as {$userSession?.email}</p>
 
 <section>
-    {#each $officeList as office (office.id)}
-        <p>{office.id}: {office.name}</p>
+    {#each Object.entries($allOffices) as [id, name] (id)}
+        <p>{id}: {name}</p>
     {:else}
         No offices available
     {/each}

--- a/client/src/pages/dashboard/stores/OfficeStore.ts
+++ b/client/src/pages/dashboard/stores/OfficeStore.ts
@@ -2,7 +2,7 @@ import { asyncReadable } from '@square/svelte-store';
 
 import { Office } from '../../../api/office.ts';
 
-export const officeList = asyncReadable(
+export const allOffices = asyncReadable(
     [],
     Office.getAll,
     { reloadable: true }

--- a/client/src/pages/dashboard/stores/OfficeStore.ts
+++ b/client/src/pages/dashboard/stores/OfficeStore.ts
@@ -3,7 +3,7 @@ import { asyncReadable } from '@square/svelte-store';
 import { Office } from '../../../api/office.ts';
 
 export const allOffices = asyncReadable(
-    [],
+    { },
     Office.getAll,
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -13,7 +13,7 @@
     import NewOffice from '../../../components/ui/forms/office/NewOffice.svelte';
     import EditOffice from '../../../components/ui/forms/office/EditOffice.svelte';
     import { userSession } from '../stores/UserStore.ts';
-    import { officeList } from '../stores/OfficeStore.ts';
+    import { allOffices } from '../stores/OfficeStore.ts';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import OfficeSelect from '../../../components/ui/OfficeSelect.svelte';
     import CreateCategory from '../../../components/ui/forms/category/CreateCategory.svelte';
@@ -37,7 +37,7 @@
     const currentlySelected = '';
 
     let currentUser: User | null = null;
-    $: currentUser = {
+    $: currentUser = $userSession === null ? null : {
         id: $userSession.id,
         name: $userSession.name,
         email: $userSession.email,
@@ -62,7 +62,7 @@
 <Button on:click={() => (showEditOffice = true)}>
     Edit an Office
 </Button>
-<Button on:click={() => (showLocalPermission = true)} disabled={$officeList.length === 0}>
+<Button on:click={() => (showLocalPermission = true)} disabled={Object.getOwnPropertyNames($allOffices).length === 0}>
     Edit Local Permission
 </Button>
 <Button on:click={() => (showCreateCategory = true)}>
@@ -92,7 +92,7 @@
 </Modal>
 
 <Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
-    Select an Office: <OfficeSelect bind:oid={selectedOffice} offices={$officeList}/>
+    Select an Office: <OfficeSelect bind:oid={selectedOffice} offices={$allOffices}/>
     <br>
     {#if selectedOffice !== null && currentUser !== null }
         <LocalPermissions user={currentUser} office={selectedOffice} />

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -58,6 +58,9 @@ export const InboxEntrySchema = SnapshotSchema
 
 export type InboxEntry = z.infer<typeof InboxEntrySchema>;
 
+export const AllOfficesSchema = z.record(OfficeSchema.shape.id, OfficeSchema.shape.name);
+export type AllOffices = z.infer<typeof AllOfficesSchema>;
+
 export const SummarySchema = z.object({
     status: StatusSchema,
     amount: z.coerce.bigint().positive(),

--- a/model/src/office.ts
+++ b/model/src/office.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const OfficeSchema = z.object({
-    id: z.number().int().positive(),
+    id: z.coerce.number().int().positive(),
     name: z.string().min(1).max(40),
 });
 

--- a/server/deno.json
+++ b/server/deno.json
@@ -10,6 +10,7 @@
         "create": "createdb -U postgres -W doctrack",
         "drop": "dropdb -U postgres -W doctrack",
         "bootstrap": "psql -U postgres -W -f db/bootstrap.sql -1 doctrack",
+        "shell": "psql -U postgres -W doctrack",
         "test": "deno test --allow-env --allow-net",
         "start": "deno run --allow-env --allow-net --allow-read src/main.ts"
     },

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -46,7 +46,8 @@ Deno.test('full OAuth flow', async t => {
     await t.step('update office information', async () => {
         assertFalse(await db.updateOffice({ id: 0, name: 'Hello' }));
         assert(await db.updateOffice({ id: office, name: 'Hello' }));
-        assertArrayIncludes(await db.getAllOffices(), [ { id: office, name: 'Hello' } ]);
+        const offices = await db.getAllOffices();
+        assertStrictEquals(offices[office], 'Hello');
     });
 
     await t.step('successfully revoke invites from the system', async () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -140,7 +140,8 @@ Deno.test('full API integration test', async t => {
 
         // Update existing office
         assert(await Office.update({ id: otherOid, name: 'New Test Office' }));
-        assertArrayIncludes(await Office.getAll(), [ { id: otherOid, name: 'New Test Office' } ]);
+        const offices = await Office.getAll();
+        assertStrictEquals(offices[otherOid], 'New Test Office');
     });
 
     await t.step('Invite API', async () => {


### PR DESCRIPTION
Per @justinruaya123's suggestion, this PR changes the return type of the `GET /api/offices` endpoint to return a dictionary of office IDs and names instead of a plain array of offices. This is more ergonomic because the dictionary allows $O(1)$ lookup.