### PR TITLE
feat(server): full Metrics API implementation

### DIFF
--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type Metrics as MetricsType, MetricsSchema } from '~model/api.ts';
+import { type UserMetrics, UserMetricsSchema } from '~model/metrics.ts';
 
 import {
     InsufficientPermissions,
@@ -10,13 +10,13 @@ import {
 } from './error.ts';
 
 export namespace Metrics {
-    export async function generateUserSummary(): Promise<MetricsType> {
+    export async function generateUserSummary(): Promise<UserMetrics> {
         const res = await fetch('/api/metrics/user', {
             credentials: 'same-origin',
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case StatusCodes.OK: return MetricsSchema.parse(await res.json());
+            case StatusCodes.OK: return UserMetricsSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,22 +1,39 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type Metrics, MetricsSchema } from '~model/metrics.ts';
+import { type Metrics as MetricsType, MetricsSchema } from '~model/metrics.ts';
+import type { Office } from '~model/office.ts';
 
 import {
     InsufficientPermissions,
+    InvalidInput,
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
 } from './error.ts';
 
 export namespace Metrics {
-    export async function generateUserSummary(): Promise<Metrics> {
+    export async function generateUserSummary(): Promise<MetricsType> {
         const res = await fetch('/api/metrics/user', {
             credentials: 'same-origin',
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
             case StatusCodes.OK: return MetricsSchema.parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
+    export async function generateLocalSummary(oid: Office['id']): Promise<MetricsType> {
+        const res = await fetch(`/api/metrics/office?id=${oid}`, {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return MetricsSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -40,4 +40,18 @@ export namespace Metrics {
             default: throw new UnexpectedStatusCode;
         }
     }
+
+    export async function generateGlobalSummary(): Promise<MetricsType> {
+        const res = await fetch('/api/metrics/system', {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return MetricsSchema.parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
 }

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type UserMetrics, UserMetricsSchema } from '~model/metrics.ts';
+import { type Metrics, MetricsSchema } from '~model/metrics.ts';
 
 import {
     InsufficientPermissions,
@@ -10,13 +10,13 @@ import {
 } from './error.ts';
 
 export namespace Metrics {
-    export async function generateUserSummary(): Promise<UserMetrics> {
+    export async function generateUserSummary(): Promise<Metrics> {
         const res = await fetch('/api/metrics/user', {
             credentials: 'same-origin',
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case StatusCodes.OK: return UserMetricsSchema.parse(await res.json());
+            case StatusCodes.OK: return MetricsSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -5,7 +5,7 @@ import { BatchSchema } from './batch.ts';
 import { CategorySchema } from './category.ts';
 import { DocumentSchema } from './document.ts';
 import { OfficeSchema } from './office.ts';
-import { SnapshotSchema, StatusSchema } from './snapshot.ts';
+import { SnapshotSchema } from './snapshot.ts';
 import { StaffSchema } from './staff.ts';
 import { UserSchema } from './user.ts';
 
@@ -60,15 +60,6 @@ export type InboxEntry = z.infer<typeof InboxEntrySchema>;
 
 export const AllOfficesSchema = z.record(OfficeSchema.shape.id, OfficeSchema.shape.name);
 export type AllOffices = z.infer<typeof AllOfficesSchema>;
-
-export const SummarySchema = z.object({
-    status: StatusSchema,
-    amount: z.coerce.bigint().positive(),
-});
-export type Summary = z.infer<typeof SummarySchema>;
-
-export const MetricsSchema = z.record(StatusSchema, SummarySchema.shape.amount);
-export type Metrics = z.infer<typeof MetricsSchema>;
 
 export const FullSessionSchema = UserSchema
     .omit({ permission: true })

--- a/model/src/metrics.ts
+++ b/model/src/metrics.ts
@@ -4,4 +4,3 @@ import { StatusSchema } from './snapshot.ts';
 
 export const MetricsSchema = z.record(StatusSchema, z.number().int().positive());
 export type Metrics = z.infer<typeof MetricsSchema>;
-

--- a/model/src/metrics.ts
+++ b/model/src/metrics.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { StatusSchema } from './snapshot.ts';
+
+export const UserMetricsSchema = z.record(StatusSchema, z.number().int().positive());
+export type UserMetrics = z.infer<typeof UserMetricsSchema>;
+

--- a/model/src/metrics.ts
+++ b/model/src/metrics.ts
@@ -2,6 +2,6 @@ import { z } from 'zod';
 
 import { StatusSchema } from './snapshot.ts';
 
-export const UserMetricsSchema = z.record(StatusSchema, z.number().int().positive());
-export type UserMetrics = z.infer<typeof UserMetricsSchema>;
+export const MetricsSchema = z.record(StatusSchema, z.number().int().positive());
+export type Metrics = z.infer<typeof MetricsSchema>;
 

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -375,11 +375,19 @@ Deno.test('full OAuth flow', async t => {
         });
 
         await t.step('user metrics are consistent', async () => {
-            const metrics = await db.generateUserSummary(USER.id);
-            assertStrictEquals(metrics[Status.Register], 1);
-            assertStrictEquals(metrics[Status.Send], 1);
-            assertStrictEquals(metrics[Status.Receive], undefined);
-            assertStrictEquals(metrics[Status.Terminate], undefined);
+            const user = await db.generateUserSummary(USER.id);
+            assertStrictEquals(user.Register, 1);
+            assertStrictEquals(user.Send, 1);
+            assertStrictEquals(user.Receive, undefined);
+            assertStrictEquals(user.Terminate, undefined);
+
+            // TODO: add tests for multiple users in the same office
+
+            const local = await db.generateLocalSummary(office);
+            assertStrictEquals(local.Register, 1);
+            assertStrictEquals(local.Send, 1);
+            assertStrictEquals(local.Receive, undefined);
+            assertStrictEquals(local.Terminate, undefined);
         });
     });
 

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -388,6 +388,12 @@ Deno.test('full OAuth flow', async t => {
             assertStrictEquals(local.Send, 1);
             assertStrictEquals(local.Receive, undefined);
             assertStrictEquals(local.Terminate, undefined);
+
+            const global = await db.generateGlobalSummary();
+            assert(global.Register ?? 0 > 0);
+            assert(global.Send ?? 0 > 0);
+            assertStrictEquals(global.Receive, undefined);
+            assertStrictEquals(global.Terminate, undefined);
         });
     });
 

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -376,10 +376,10 @@ Deno.test('full OAuth flow', async t => {
 
         await t.step('user metrics are consistent', async () => {
             const metrics = await db.generateUserSummary(USER.id);
-            assertStrictEquals(metrics.get(Status.Register), 1n);
-            assertStrictEquals(metrics.get(Status.Send), 1n);
-            assertStrictEquals(metrics.get(Status.Receive), undefined);
-            assertStrictEquals(metrics.get(Status.Terminate), undefined);
+            assertStrictEquals(metrics[Status.Register], 1);
+            assertStrictEquals(metrics[Status.Send], 1);
+            assertStrictEquals(metrics[Status.Receive], undefined);
+            assertStrictEquals(metrics[Status.Terminate], undefined);
         });
     });
 

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -578,4 +578,11 @@ export class Database {
         assertStrictEquals(rest.length, 0);
         return z.object({ result: MetricsSchema }).parse(first).result;
     }
+
+    async generateGlobalSummary(): Promise<Metrics> {
+        const { rows: [ first, ...rest ] } = await this.#client
+            .queryObject("WITH _ AS (SELECT status,COUNT(status) AS amount FROM snapshot GROUP BY status) SELECT coalesce(json_object_agg(status,amount),'{}') AS result FROM _");
+        assertStrictEquals(rest.length, 0);
+        return z.object({ result: MetricsSchema }).parse(first).result;
+    }
 }

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -514,7 +514,7 @@ export class Database {
     /** Get all offices from the system. */
     async getAllOffices(): Promise<AllOffices> {
         const { rows: [ first, ...rest ] } = await this.#client
-            .queryObject("SELECT coalesce(json_object(array_agg(id::text), array_agg(name)), '{}') AS result FROM office;");
+            .queryObject("SELECT coalesce(json_object_agg(id,name),'{}') AS result FROM office;");
         assertStrictEquals(rest.length, 0);
         return z.object({ result: AllOfficesSchema }).parse(first).result;
     }
@@ -561,7 +561,7 @@ export class Database {
     async generateUserSummary(uid: User['id']): Promise<UserMetrics> {
         const { rows: [ first, ...rest ] } = await this.#client
             .queryObject`WITH _ AS (SELECT status,COUNT(status) AS amount FROM snapshot WHERE evaluator = ${uid} GROUP BY status)
-                SELECT coalesce(json_object_agg(status,amount)) AS result FROM _`;
+                SELECT coalesce(json_object_agg(status,amount),'{}') AS result FROM _`;
         assertStrictEquals(rest.length, 0);
         return z.object({ result: UserMetricsSchema }).parse(first).result;
     }

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -27,7 +27,7 @@ import { type Barcode, BarcodeSchema } from '~model/barcode.ts';
 import { type Batch, BatchSchema, } from '~model/batch.ts';
 import { type Category, CategorySchema } from '~model/category.ts';
 import { type Invitation, InvitationSchema } from '~model/invitation.ts';
-import { type UserMetrics, UserMetricsSchema } from '~model/metrics.ts';
+import { type Metrics, MetricsSchema } from '~model/metrics.ts';
 import { type Office, OfficeSchema } from '~model/office.ts';
 import { type Pending, PendingSchema } from '~model/pending.ts';
 import { type Session, SessionSchema } from '~model/session.ts';
@@ -558,11 +558,11 @@ export class Database {
     }
 
     /** Generate a user-centric summary of the metrics (across all offices). */
-    async generateUserSummary(uid: User['id']): Promise<UserMetrics> {
+    async generateUserSummary(uid: User['id']): Promise<Metrics> {
         const { rows: [ first, ...rest ] } = await this.#client
             .queryObject`WITH _ AS (SELECT status,COUNT(status) AS amount FROM snapshot WHERE evaluator = ${uid} GROUP BY status)
                 SELECT coalesce(json_object_agg(status,amount),'{}') AS result FROM _`;
         assertStrictEquals(rest.length, 0);
-        return z.object({ result: UserMetricsSchema }).parse(first).result;
+        return z.object({ result: MetricsSchema }).parse(first).result;
     }
 }

--- a/server/src/routes/api/metrics.ts
+++ b/server/src/routes/api/metrics.ts
@@ -4,7 +4,7 @@ import { error, info } from 'log';
 import { accepts } from 'negotiation';
 import { Pool } from 'postgres';
 
-import { Global } from '~model/permission.ts';
+import { Global, Local } from '~model/permission.ts';
 
 import { Database } from '../../database.ts';
 
@@ -47,6 +47,66 @@ export async function handleGenerateUserSummary(pool: Pool, req: Request) {
 
         const metrics = await db.generateUserSummary(user.id);
         info(`[Metrics] User ${user.id} ${user.name} <${user.email}> viewed user-global summary`);
+        return new Response(JSON.stringify(metrics), {
+            headers: { 'Content-Type': 'application/json' },
+        });
+    } finally {
+        db.release();
+    }
+}
+
+/**
+ * Gets the summary of an office's metrics.
+ *
+ * # Inputs
+ * - Requires a session whose local permissions include {@linkcode Local.ViewMetrics}
+ *
+ * # Outputs
+ * - `200` => returns the counts of the grouped snapshots as JSON in the {@linkcode Response} body
+ * - `400` => office ID is absent or otherwise malformed
+ * - `401` => session ID is absent, expired, or otherwise malformed
+ * - `403` => insufficient permissions
+ * - `406` => content negotiation failed
+ */
+export async function handleGenerateLocalSummary(pool: Pool, req: Request, params: URLSearchParams) {
+    const { sid } = getCookies(req.headers);
+    if (!sid) {
+        error('[Metrics] Absent session ID');
+        return new Response(null, { status: Status.Unauthorized });
+    }
+
+    if (accepts(req, 'application/json') === undefined) {
+        error(`[Metrics] Content negotiation failed for session ${sid}`);
+        return new Response(null, { status: Status.NotAcceptable });
+    }
+
+    const input = params.get('id');
+    if (!input) {
+        error(`[Metrics] Session ${sid} provided an empty office ID`);
+        return new Response(null, { status: Status.BadRequest });
+    }
+
+    const oid = parseInt(input, 10);
+    if (isNaN(oid)) {
+        error(`[Metrics] Session ${sid} provided an invalid office ID "${input}"`);
+        return new Response(null, { status: Status.BadRequest });
+    }
+
+    const db = await Database.fromPool(pool);
+    try {
+        const staff = await db.getStaffFromSession(sid, oid);
+        if (staff === null) {
+            error(`[Metrics] Invalid session ${sid}`);
+            return new Response(null, { status: Status.Unauthorized });
+        }
+
+        if ((staff.permission & Local.ViewMetrics) !== Local.ViewMetrics) {
+            error(`[Metrics] Staff ${staff.user_id} of office ${oid} cannot view office summary`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
+        const metrics = await db.generateLocalSummary(oid);
+        info(`[Metrics] Staff ${staff.user_id} of office ${oid} viewed the office summary`);
         return new Response(JSON.stringify(metrics), {
             headers: { 'Content-Type': 'application/json' },
         });

--- a/server/src/routes/api/metrics.ts
+++ b/server/src/routes/api/metrics.ts
@@ -1,6 +1,5 @@
 import { getCookies } from 'cookie';
 import { Status } from 'http';
-import { map } from 'itertools';
 import { error, info } from 'log';
 import { accepts } from 'negotiation';
 import { Pool } from 'postgres';
@@ -48,10 +47,7 @@ export async function handleGenerateUserSummary(pool: Pool, req: Request) {
 
         const metrics = await db.generateUserSummary(user.id);
         info(`[Metrics] User ${user.id} ${user.name} <${user.email}> viewed user-global summary`);
-
-        const entries = map(metrics.entries(), ([ status, amount ]) => [ status, amount.toString() ] as const);
-        const json = Object.fromEntries(entries);
-        return new Response(JSON.stringify(json), {
+        return new Response(JSON.stringify(metrics), {
             headers: { 'Content-Type': 'application/json' },
         });
     } finally {

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -16,7 +16,7 @@ import {
 } from './api/category.ts';
 import { handleCreateDocument, handleGetInbox, handleGetPaperTrail } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation } from './api/invite.ts';
-import { handleGenerateUserSummary } from './api/metrics.ts';
+import { handleGenerateLocalSummary, handleGenerateUserSummary } from './api/metrics.ts';
 import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
@@ -35,6 +35,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/categories': return handleGetAllCategories(pool, req);
         case '/api/document': return handleGetPaperTrail(pool, req, searchParams);
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
+        case '/api/metrics/office': return handleGenerateLocalSummary(pool, req, searchParams);
         case '/api/metrics/user': return handleGenerateUserSummary(pool, req);
         case '/api/offices': return handleGetAllOffices(pool, req);
         case '/api/session': return handleGetUserFromSession(pool, req);

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -16,7 +16,7 @@ import {
 } from './api/category.ts';
 import { handleCreateDocument, handleGetInbox, handleGetPaperTrail } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation } from './api/invite.ts';
-import { handleGenerateLocalSummary, handleGenerateUserSummary } from './api/metrics.ts';
+import { handleGenerateGlobalSummary, handleGenerateLocalSummary, handleGenerateUserSummary } from './api/metrics.ts';
 import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
@@ -36,6 +36,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/document': return handleGetPaperTrail(pool, req, searchParams);
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
         case '/api/metrics/office': return handleGenerateLocalSummary(pool, req, searchParams);
+        case '/api/metrics/system': return handleGenerateGlobalSummary(pool, req);
         case '/api/metrics/user': return handleGenerateUserSummary(pool, req);
         case '/api/offices': return handleGetAllOffices(pool, req);
         case '/api/session': return handleGetUserFromSession(pool, req);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -248,12 +248,19 @@ Deno.test('full API integration test', async t => {
     });
 
     await t.step('Metrics API', async () => {
-        const summary = await Metrics.generateUserSummary();
-        assert(summary !== undefined);
-        assertStrictEquals(summary.Register, 1);
-        assertStrictEquals(summary.Send, 1);
-        assertStrictEquals(summary.Receive, undefined);
-        assertStrictEquals(summary.Terminate, undefined);
+        const user = await Metrics.generateUserSummary();
+        assertStrictEquals(user.Register, 1);
+        assertStrictEquals(user.Send, 1);
+        assertStrictEquals(user.Receive, undefined);
+        assertStrictEquals(user.Terminate, undefined);
+
+        // TODO: add tests for multiple users in the same office
+
+        const local = await Metrics.generateLocalSummary(oid);
+        assertStrictEquals(local.Register, 1);
+        assertStrictEquals(local.Send, 1);
+        assertStrictEquals(local.Receive, undefined);
+        assertStrictEquals(local.Terminate, undefined);
     });
 
     await t.step('Category API - retirement', async () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -261,6 +261,12 @@ Deno.test('full API integration test', async t => {
         assertStrictEquals(local.Send, 1);
         assertStrictEquals(local.Receive, undefined);
         assertStrictEquals(local.Terminate, undefined);
+
+        const global = await Metrics.generateGlobalSummary();
+        assert(global.Register ?? 0 > 0);
+        assert(global.Send ?? 0 > 0);
+        assertStrictEquals(global.Receive, undefined);
+        assertStrictEquals(global.Terminate, undefined);
     });
 
     await t.step('Category API - retirement', async () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -250,8 +250,8 @@ Deno.test('full API integration test', async t => {
     await t.step('Metrics API', async () => {
         const summary = await Metrics.generateUserSummary();
         assert(summary !== undefined);
-        assertStrictEquals(summary.Register, 1n);
-        assertStrictEquals(summary.Send, 1n);
+        assertStrictEquals(summary.Register, 1);
+        assertStrictEquals(summary.Send, 1);
         assertStrictEquals(summary.Receive, undefined);
         assertStrictEquals(summary.Terminate, undefined);
     });


### PR DESCRIPTION
Blocked by #56.

This PR finally completes the basic implementation of the Metrics API.

Endpoint | Description | Permission
--- | --- | ---
`GET /api/metrics/user` | User-level Metrics | `Global.ViewMetrics`
`GET /api/metrics/office` | Office-level Metrics | `Local.ViewMetrics`
`GET /api/metrics/system` | System-level Metrics | `Global.ViewMetrics`

For all endpoints, they return a `Record<Status, number>` as JSON. Additional information such as average turnaround times may be implemented in a future PR.