### PR TITLE
feat(client): create currentUser to derive from (full) userSession.

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
     plugins: [
         'svelte3',
         '@typescript-eslint',
+        'square-svelte-store',
     ],
     overrides: [
         {
@@ -40,6 +41,7 @@ module.exports = {
         'no-unused-private-class-members': 'error',
         'no-use-before-define': 'error',
         'require-atomic-updates': 'error',
+        'square-svelte-store/use-square-svelte-stores': 'error',
 
         // Suggestions
         'block-scoped-var': 'error',

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
         "eslint": "^8.38.0",
+        "eslint-plugin-square-svelte-store": "^1.0.0",
         "eslint-plugin-svelte3": "^4.0.0",
         "parcel": "^2.8.3",
         "svelte": "^3.58.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -111,6 +111,9 @@ devDependencies:
   eslint:
     specifier: ^8.38.0
     version: 8.38.0
+  eslint-plugin-square-svelte-store:
+    specifier: ^1.0.0
+    version: 1.0.0
   eslint-plugin-svelte3:
     specifier: ^4.0.0
     version: 4.0.0(eslint@8.38.0)(svelte@3.58.0)
@@ -1079,6 +1082,18 @@ packages:
       typescript: 5.0.4
     dev: true
 
+  /@parcel/types@2.8.3:
+    resolution: {integrity: sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==}
+    dependencies:
+      '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/diagnostic': 2.8.3
+      '@parcel/fs': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/package-manager': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/source-map': 2.1.1
+      '@parcel/workers': 2.8.3(@parcel/core@2.8.3)
+      utility-types: 3.10.0
+    dev: true
+
   /@parcel/types@2.8.3(@parcel/core@2.8.3):
     resolution: {integrity: sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==}
     dependencies:
@@ -1126,7 +1141,7 @@ packages:
       '@parcel/core': 2.8.3
       '@parcel/diagnostic': 2.8.3
       '@parcel/logger': 2.8.3
-      '@parcel/types': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/types': 2.8.3
       '@parcel/utils': 2.8.3
       chrome-trace-event: 1.0.3
       nullthrows: 1.1.1
@@ -1766,6 +1781,10 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-plugin-square-svelte-store@1.0.0:
+    resolution: {integrity: sha512-QLybNNEPcBKVrgAeow/7ouOqbTVsWwEdStFab9ZMZaW19Y//ZEhhtuEb92P69n9u/JRL6EFhArV9AfS+LgS4mA==}
     dev: true
 
   /eslint-plugin-svelte3@4.0.0(eslint@8.38.0)(svelte@3.58.0):

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script>
     import Router from 'svelte-spa-router';
 
-    import { userSession } from './stores/UserStore.ts';
+    import { userSession, currentUser } from './stores/UserStore.ts';
 
     import TopBar from '../../components/ui/navigationbar/TopBar.svelte';
     import SideDrawer from '../../components/ui/navigationbar/SideDrawer.svelte';
@@ -18,8 +18,8 @@
     {:then}
         {#await userSession.load()}
             Loading user...
-        {:then user}
-            <TopBar {user} bind:show={toggleDrawer} />
+        {:then}
+            <TopBar {$currentUser} bind:show={toggleDrawer} />
             <section>
                 <SideDrawer show={toggleDrawer} />
                 <Router {routes} />

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script>
     import Router from 'svelte-spa-router';
 
-    import { userSession, currentUser } from './stores/UserStore.ts';
+    import { currentUser } from './stores/UserStore.ts';
 
     import TopBar from '../../components/ui/navigationbar/TopBar.svelte';
     import SideDrawer from '../../components/ui/navigationbar/SideDrawer.svelte';
@@ -16,10 +16,10 @@
     {#await register()}
         Waiting for service worker...
     {:then}
-        {#await userSession.load()}
+        {#await currentUser.load()}
             Loading user...
-        {:then}
-            <TopBar {$currentUser} bind:show={toggleDrawer} />
+        {:then user}
+            <TopBar {user} bind:show={toggleDrawer} />
             <section>
                 <SideDrawer show={toggleDrawer} />
                 <Router {routes} />

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -1,7 +1,6 @@
-import { asyncReadable } from '@square/svelte-store';
+import { asyncReadable, derived } from '@square/svelte-store';
 
 import { Session } from '../../../api/session.ts';
-import { derived } from 'svelte/store';
 import { User } from '~model/user.ts';
 
 export const userSession = asyncReadable(
@@ -10,10 +9,10 @@ export const userSession = asyncReadable(
     { reloadable: true }
 );
 
-export const currentUser = derived(userSession, session => ({
-    id: session?.id,
-    name: session?.name,
-    email: session?.email,
-    picture: session?.picture,
-    permission: session?.global_perms,
-} as User));
+export const currentUser = derived(userSession, session => session ===  null ? null : {
+    id: session.id,
+    name: session.name,
+    email: session.email,
+    picture: session.picture,
+    permission: session.global_perms,
+} as User);

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -1,9 +1,19 @@
 import { asyncReadable } from '@square/svelte-store';
 
 import { Session } from '../../../api/session.ts';
+import { derived } from 'svelte/store';
+import { User } from '~model/user.ts';
 
 export const userSession = asyncReadable(
     null,
     Session.getUser,
     { reloadable: true }
 );
+
+export const currentUser = derived(userSession, session => ({
+    id: session?.id,
+    name: session?.name,
+    email: session?.email,
+    picture: session?.picture,
+    permission: session?.global_perms
+} as User));

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -9,7 +9,7 @@ export const userSession = asyncReadable(
     { reloadable: true }
 );
 
-export const currentUser = derived(userSession, session => session ===  null ? null : {
+export const currentUser = derived(userSession, session => session === null ? null : {
     id: session.id,
     name: session.name,
     email: session.email,

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -15,5 +15,5 @@ export const currentUser = derived(userSession, session => ({
     name: session?.name,
     email: session?.email,
     picture: session?.picture,
-    permission: session?.global_perms
+    permission: session?.global_perms,
 } as User));

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { User } from '~model/user.ts';
-
     import { documentTest } from './sample.ts';
     import { RowEvent, RowType } from '../../../components/types.ts';
 
@@ -12,7 +10,7 @@
     import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
     import NewOffice from '../../../components/ui/forms/office/NewOffice.svelte';
     import EditOffice from '../../../components/ui/forms/office/EditOffice.svelte';
-    import { userSession } from '../stores/UserStore.ts';
+    import { currentUser } from '../stores/UserStore.ts';
     import { allOffices } from '../stores/OfficeStore.ts';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import OfficeSelect from '../../../components/ui/OfficeSelect.svelte';
@@ -35,15 +33,6 @@
     let showActivateCategory = false;
 
     const currentlySelected = '';
-
-    let currentUser: User | null = null;
-    $: currentUser = $userSession === null ? null : {
-        id: $userSession.id,
-        name: $userSession.name,
-        email: $userSession.email,
-        picture: $userSession.picture,
-        permission: $userSession.global_perms,
-    };
 
     function overflowClickHandler(e: CustomEvent<RowEvent>) {
         if (!e.detail) return;
@@ -94,17 +83,15 @@
 <Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
     Select an Office: <OfficeSelect bind:oid={selectedOffice} offices={$allOffices}/>
     <br>
-    {#if selectedOffice !== null && currentUser !== null }
-        <LocalPermissions user={currentUser} office={selectedOffice} />
+    {#if selectedOffice !== null}
+        <LocalPermissions user={$currentUser} office={selectedOffice} />
     {:else}
         Current user is not a staff of the selected office.
     {/if}
 </Modal>
 
 <Modal title="Edit Global Permissions" bind:showModal={showPermission}>
-    {#if currentUser !== null}
-        <GlobalPermissions user={currentUser} />
-    {/if}
+    <GlobalPermissions user={$currentUser} />
 </Modal>
 
 <Modal title="Create New Office" bind:showModal={showCreateOffice}>


### PR DESCRIPTION
PR aims to add a `currentUser` store that derives from the `userSession` store. This allows us to give to certain components only a subset of the information in a `userSession` for an easier time. i.e. Top nav does not need anything aside from the name, so we give it `currentUser` store instead of an entire `userSession` store.