### PR TITLE
feat(client): adapt document title according to current office + resolve most lint warnings

### DIFF
--- a/client/src/api/vapid.ts
+++ b/client/src/api/vapid.ts
@@ -7,7 +7,7 @@ export namespace Vapid {
     /** @returns VAPID public key of the server as raw bytes */
     export async function getVapidPublicKey(): Promise<ArrayBuffer> {
         const res = await fetch('/api/vapid', { headers: { 'Accept': 'application/octet-stream' } });
-        if (res.status === StatusCodes.OK) return res.arrayBuffer();
+        if (res.status === Number(StatusCodes.OK)) return res.arrayBuffer();
         throw new UnexpectedStatusCode;
     }
 
@@ -30,7 +30,7 @@ export namespace Vapid {
             }),
         });
 
-        if (res.status === StatusCodes.CREATED) return;
+        if (res.status === Number(StatusCodes.CREATED)) return;
         throw new UnexpectedStatusCode;
     }
 }

--- a/client/src/components/ui/Button.svelte
+++ b/client/src/components/ui/Button.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { ButtonType } from '../types.ts';
     export let type: ButtonType = ButtonType.Primary;
-    export let submit = false;
-    export let disabled = false;
+    export let submit = false as boolean;
+    export let disabled = false as boolean;
 </script>
 
 <button type={submit ? 'submit' : 'button'} class={type} {disabled} on:click>

--- a/client/src/components/ui/Modal.svelte
+++ b/client/src/components/ui/Modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Close from '../icons/Close.svelte';
 
-    export let showModal = false;
+    export let showModal = false as boolean;
     export let title: string;
 
     let dialog: HTMLDialogElement | null = null;

--- a/client/src/components/ui/contextmenu/ContextTemplate.svelte
+++ b/client/src/components/ui/contextmenu/ContextTemplate.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    export let show = false;
+    export let show = false as boolean;
 
     let context: HTMLDialogElement | null = null;
 

--- a/client/src/components/ui/forms/category/ActivateCategory.svelte
+++ b/client/src/components/ui/forms/category/ActivateCategory.svelte
@@ -9,17 +9,14 @@
     import Edit from '../../../icons/Edit.svelte';
     import CategorySelect from '../../CategorySelect.svelte';
 
-    let currId: CategoryModel['id'] | null = null;
-    let currName: CategoryModel['name'] | null = null;
+    let catId: CategoryModel['id'] | null = null;
 
-    $: currName = $categoryList?.retire.find(cat => cat.id === currId)?.name ?? null;
-    
     async function handleSubmit(this: HTMLFormElement) {
-        if (currId === null) return;
+        if (catId === null) return;
         if (!this.reportValidity()) return;
 
         try {
-            await Category.activate(currId);
+            await Category.activate(catId);
             await categoryList.reload?.();
             this.reset();
         } catch (err) {
@@ -32,19 +29,15 @@
 <p>You are currently reactivating a category as {$userSession?.email}</p>
 
 <article>
-    {#if $categoryList.retire.length === 0}
-        No categories to edit.
-    {:else}
+    {#await categoryList.load()}
+        Loading list of retired categories...
+    {:then { retire: categories }}
         <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-            <CategorySelect bind:catId={currId} categories={$categoryList.retire}/>
-            <br/>
-            {#if typeof currId === 'number'}
-                <p>Category ID: {currId}</p>
-                <p>Category Name: {currName}</p>
-                {#if currName !== null}
-                    <Button submit><Edit color={IconColor.White} alt="Reactivate Category"/> Reactivate Category</Button>
-                {/if}
+            <CategorySelect bind:catId {categories} />
+            <br />
+            {#if typeof catId === 'number'}
+                <Button submit><Edit color={IconColor.White} alt="Reactivate Category" /> Reactivate Category</Button>
             {/if}
         </form>
-    {/if}
+    {/await}
 </article>

--- a/client/src/components/ui/forms/category/RemoveCategory.svelte
+++ b/client/src/components/ui/forms/category/RemoveCategory.svelte
@@ -9,15 +9,14 @@
     import Close from '../../../icons/Close.svelte';
     import CategorySelect from '../../CategorySelect.svelte';
 
-    let currId: CategoryModel['id'] | null = null;
-    let currName: CategoryModel['name'] | null = null;
-    $: currName = $categoryList?.active.find(cat => cat.id === currId)?.name ?? null;
+    let catId: CategoryModel['id'] | null = null;
 
     async function handleSubmit(this: HTMLFormElement) {
-        if (currId === null || currName === null) return;
+        if (catId === null) return;
+        if (!this.reportValidity()) return;
 
         try {
-            await Category.remove(currId);
+            await Category.remove(catId);
             await categoryList.reload?.();
             this.reset();
         } catch (err) {
@@ -30,13 +29,13 @@
 <p>You are currently removing a category as {$userSession?.email}</p>
 
 <article>
-    {#if $categoryList.active.length === 0}
-        No categories to edit.
-    {:else}
+    {#await categoryList.load()}
+        Loading list of removable categories...
+    {:then { active: categories }}
         <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-            <CategorySelect bind:catId={currId} categories={$categoryList.active} />
-            <br/>
+            <CategorySelect bind:catId {categories} />
+            <br />
             <Button type={ButtonType.Danger} submit><Close color={IconColor.White} alt="Edit Category" /> Remove Category</Button>
         </form>
-    {/if}
+    {/await}
 </article>

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -16,7 +16,7 @@
     
     export let payload: ContextPayload;
     export let userOfficeId: Office['id'];
-    export let status: Status | null = null;
+    export let status: Status;
 
     let destOfficeId: SnapshotModel['target'] | null = null;
 
@@ -26,13 +26,8 @@
         assert(node.type === 'text');
     
         if (status === Status.Receive) destOfficeId = userOfficeId;
-        if (status === Status.Terminate)
-            destOfficeId = null;
-        else
-            assert(destOfficeId !== null);
-    
-        assert(userOfficeId !== null);
-        assert(status !== null);
+        if (status === Status.Terminate) destOfficeId = null;
+        else assert(destOfficeId !== null);
         assert(payload.id);
 
         try {

--- a/client/src/components/ui/forms/office/EditOffice.svelte
+++ b/client/src/components/ui/forms/office/EditOffice.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { assert } from '../../../../assert.ts';
-
     import { Office as OfficeModel } from '../../../../../../model/src/office.ts';
 
     import { Office } from '../../../../api/office.ts';

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
 
     import { User } from '../../../../api/user.ts';
@@ -48,7 +49,7 @@
             type="checkbox"
             name="perms"
             value={Global.GetOffices}
-            checked={(user.permission & Global.GetOffices) === Global.GetOffices}
+            checked={checkPerms(user.permission, Global.GetOffices)}
         />
         Get Offices
     </label>
@@ -57,7 +58,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateOffice}
-            checked={(user.permission & Global.CreateOffice) === Global.CreateOffice}
+            checked={checkPerms(user.permission, Global.CreateOffice)}
         />
         Create Office
     </label>
@@ -66,7 +67,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateOffice}
-            checked={(user.permission & Global.UpdateOffice) === Global.UpdateOffice}
+            checked={checkPerms(user.permission, Global.UpdateOffice)}
         />
         Update Office
     </label>
@@ -75,7 +76,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateUser}
-            checked={(user.permission & Global.UpdateUser) === Global.UpdateUser}
+            checked={checkPerms(user.permission, Global.UpdateUser)}
         />
         Update User
     </label>
@@ -84,7 +85,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateCategory}
-            checked={(user.permission & Global.CreateCategory) === Global.CreateCategory}
+            checked={checkPerms(user.permission, Global.CreateCategory)}
         />
         Create Category
     </label>
@@ -93,7 +94,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateCategory}
-            checked={(user.permission & Global.UpdateCategory) === Global.UpdateCategory}
+            checked={checkPerms(user.permission, Global.UpdateCategory)}
         />
         Update Category
     </label>
@@ -102,7 +103,7 @@
             type="checkbox"
             name="perms"
             value={Global.DeleteCategory}
-            checked={(user.permission & Global.DeleteCategory) === Global.DeleteCategory}
+            checked={checkPerms(user.permission, Global.DeleteCategory)}
         />
         Delete Category
     </label>
@@ -111,7 +112,7 @@
             type="checkbox"
             name="perms"
             value={Global.ActivateCategory}
-            checked={(user.permission & Global.ActivateCategory) === Global.ActivateCategory}
+            checked={checkPerms(user.permission, Global.ActivateCategory)}
         />
         Activate Category
     </label>
@@ -120,7 +121,7 @@
             type="checkbox"
             name="perms"
             value={Global.ViewMetrics}
-            checked={(user.permission & Global.ViewMetrics) === Global.ViewMetrics}
+            checked={checkPerms(user.permission, Global.ViewMetrics)}
         />
         View Metrics
     </label>

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+    import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
-
-    import { Staff } from '../../../../api/staff.ts';
-    import type { User as UserModel } from '../../../../../../model/src/user.ts';
-    import { Local } from '../../../../../../model/src/permission.ts';
-    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
     import { IconColor } from '../../../types.ts';
+    import { Staff } from '../../../../api/staff.ts';
+
+    import { Local } from '../../../../../../model/src/permission.ts';
+    import type { User as UserModel } from '../../../../../../model/src/user.ts';
+
+    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
+
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 
@@ -50,7 +53,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={(user.permission & Local.AddStaff) === Local.AddStaff}
+            checked={checkPerms(user.permission, Local.AddStaff)}
         />
         Add Staff
     </label>
@@ -59,7 +62,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={(user.permission & Local.RemoveStaff) === Local.RemoveStaff}
+            checked={checkPerms(user.permission, Local.RemoveStaff)}
         />
         Remove Staff
     </label>
@@ -68,7 +71,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={(user.permission & Local.UpdateStaff) === Local.UpdateStaff}
+            checked={checkPerms(user.permission, Local.UpdateStaff)}
         />
         Update Staff
     </label>
@@ -77,7 +80,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={(user.permission & Local.AddInvite) === Local.AddInvite}
+            checked={checkPerms(user.permission, Local.AddInvite)}
         />
         Add Invite
     </label>
@@ -86,7 +89,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={(user.permission & Local.RevokeInvite) === Local.RevokeInvite}
+            checked={checkPerms(user.permission, Local.RevokeInvite)}
         />
         Revoke Invite
     </label>
@@ -95,7 +98,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={(user.permission & Local.ViewBatch) === Local.ViewBatch}
+            checked={checkPerms(user.permission, Local.ViewBatch)}
         />
         View Batch
     </label>
@@ -104,7 +107,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={(user.permission & Local.GenerateBatch) === Local.GenerateBatch}
+            checked={checkPerms(user.permission, Local.GenerateBatch)}
         />
         Generate Batch
     </label>
@@ -113,7 +116,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={(user.permission & Local.InvalidateBatch) === Local.InvalidateBatch}
+            checked={checkPerms(user.permission, Local.InvalidateBatch)}
         />
         Invalidate Batch
     </label>
@@ -122,7 +125,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={(user.permission & Local.CreateDocument) === Local.CreateDocument}
+            checked={checkPerms(user.permission, Local.CreateDocument)}
         />
         Create Document
     </label>
@@ -131,7 +134,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={(user.permission & Local.InsertSnapshot) === Local.InsertSnapshot}
+            checked={checkPerms(user.permission, Local.InsertSnapshot)}
         />
         Insert Snapshot
     </label>
@@ -140,7 +143,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={(user.permission & Local.ViewMetrics) === Local.ViewMetrics}
+            checked={checkPerms(user.permission, Local.ViewMetrics)}
         />
         View Metrics
     </label>
@@ -149,7 +152,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={(user.permission & Local.ViewInbox) === Local.ViewInbox}
+            checked={checkPerms(user.permission, Local.ViewInbox)}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/permissions/util.ts
+++ b/client/src/components/ui/forms/permissions/util.ts
@@ -1,0 +1,6 @@
+import { Global, Local } from '../../../../../../model/src/permission.ts';
+
+export function checkPerms(perms: number, mask: Global | Local) {
+    const bits = Number(mask);
+    return (perms & bits) === bits;
+}

--- a/client/src/components/ui/navigationbar/SideDrawer.svelte
+++ b/client/src/components/ui/navigationbar/SideDrawer.svelte
@@ -17,7 +17,7 @@
     export let show = false;
 
     let selectedOffice: Office['id'] | null = null;
-    $: if (selectedOffice !== null) dashboardState.setOffice(selectedOffice);
+    $: dashboardState.setOffice(selectedOffice);
 </script>
 
 <nav class:show on:click|stopPropagation on:keypress>

--- a/client/src/components/ui/navigationbar/TopBar.svelte
+++ b/client/src/components/ui/navigationbar/TopBar.svelte
@@ -5,13 +5,25 @@
 
     import { ButtonType, IconColor } from '../../../components/types.ts';
     import type { User } from '../../../../../model/src/user.ts';
+    import { dashboardState } from '../../../pages/dashboard/stores/DashboardState.ts';
+    import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
 
     export let open = false;
     export let user: User;
+
+    $: maybeOfficeName = $dashboardState.currentOffice === null
+        ? null
+        : $allOffices[$dashboardState.currentOffice];
+    $: officeName = maybeOfficeName ?? '';
 </script>
 
 <nav id="navcontainer" on:click|stopPropagation on:keypress>
-    <span id="icon"><Hamburger bind:open on:click={() => (open = !open)} /> DocTrack</span>
+    <span id="icon">
+        <Hamburger bind:open on:click={() => (open = !open)} /> DocTrack 
+        {#if officeName}
+            <span> - {officeName}</span>
+        {/if}
+    </span>
     <nav id="profilenav">
         {#if typeof user === 'undefined'} 
             <a href="/">

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -1,7 +1,9 @@
-<script>
+<script lang="ts">
     import Router from 'svelte-spa-router';
 
     import { currentPage } from './stores/CurrentPage.ts';
+    import { dashboardState } from './stores/DashboardState.ts';
+    import { allOffices } from './stores/OfficeStore.ts';
     import { currentUser } from './stores/UserStore.ts';
 
     import TopBar from '../../components/ui/navigationbar/TopBar.svelte';
@@ -11,10 +13,16 @@
     import { register } from '../register.ts';
 
     let toggleDrawer = false;
+
+    $: pageName = $currentPage || 'DocTrack';
+    $: maybeOfficeName = $dashboardState.currentOffice === null
+        ? null
+        : $allOffices[$dashboardState.currentOffice];
+    $: officeName = maybeOfficeName ?? '[No Office]';
 </script>
 
 <svelte:head>
-    <title>{$currentPage}</title>
+    <title>{pageName} - {officeName}</title>
 </svelte:head>
 
 {#await currentUser.load()}

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -25,27 +25,23 @@
     <title>{pageName} - {officeName}</title>
 </svelte:head>
 
-{#await currentUser.load()}
+{#if $currentUser === null}
     <p>Loading user...</p>
-{:then user}
-    {#if user === null}
-        <span>No user available...</span>
-    {:else}
-        <TopBar {user} bind:open={toggleDrawer} />
-        <main on:click={() => (toggleDrawer &&= false)} on:keydown>
-            {#await register()}
-                <p>Waiting for service worker...</p>
-            {:then}
-                <SideDrawer show={toggleDrawer} />
-                <section>
-                    <Router {routes} />
-                </section>
-            {:catch error}
-                <p>{error} <a href="/auth/login">Try logging in again?</a></p>
-            {/await}
-        </main>
-    {/if}
-{/await}
+{:else}
+    <TopBar user={$currentUser} bind:open={toggleDrawer} />
+    <main on:click={() => (toggleDrawer &&= false)} on:keydown>
+        {#await register()}
+            <p>Waiting for service worker...</p>
+        {:then}
+            <SideDrawer show={toggleDrawer} />
+            <section>
+                <Router {routes} />
+            </section>
+        {:catch error}
+            <p>{error} <a href="/auth/login">Try logging in again?</a></p>
+        {/await}
+    </main>
+{/if}
 
 <style>
     :global(body) {

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script>
     import Router from 'svelte-spa-router';
 
     import { currentPage } from './stores/CurrentPage.ts';

--- a/client/src/pages/dashboard/stores/DashboardState.ts
+++ b/client/src/pages/dashboard/stores/DashboardState.ts
@@ -13,7 +13,7 @@ const { subscribe, update } = writable({
 export const dashboardState = {
     subscribe,
     /** You can use `$dashboardState.setOffice(number)` to set an office. */
-    setOffice(officeId: Office['id']) {
+    setOffice(officeId: Office['id'] | null) {
         update(state => {
             state.currentOffice = officeId;
             return state;

--- a/client/src/pages/dashboard/views/Barcodes.svelte
+++ b/client/src/pages/dashboard/views/Barcodes.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { Office } from '~model/office';
     import { dashboardState } from '../stores/DashboardState.ts';
     import { Batch } from '../../../api/batch.ts';
     import { earliestBatch } from '../../dashboard/stores/BatchStore.ts';
@@ -17,10 +16,7 @@
 
     import { ButtonType } from '../../../components/types.ts';
 
-    let currentOffice: Office['id'] | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 
     let showGenerateBatch = false;
     let showDownloadBatch = false;
@@ -28,7 +24,9 @@
     async function handleGenerate() {
         if (currentOffice === null) return;
         try {
-            await Batch.generate(currentOffice);
+            // HACK: Type-cast is necessary here because for some reason,
+            // ESLint resolves the `currentOffice` as `any` type.
+            await Batch.generate(currentOffice as number);
             await earliestBatch.reload?.();
             showGenerateBatch = true;
         } catch (err) {
@@ -39,7 +37,6 @@
 
     async function handleDownload() {
         if (currentOffice === null) return;
-
         try {
             await earliestBatch.reload?.();
             showDownloadBatch = true;
@@ -91,8 +88,6 @@
         </Modal>
     </main>
 {/if}
-
-
 
 <style>
     main {

--- a/client/src/pages/dashboard/views/Drafts.svelte
+++ b/client/src/pages/dashboard/views/Drafts.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    import { Office } from '~model/office';
+<script>
     import { dashboardState } from '../stores/DashboardState';
 
-    let currentOffice: Office['id'] | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 </script>
 
 {#if currentOffice === null}

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -18,8 +18,8 @@
     let showAcceptContextMenu = false;
     let showInboxContextMenu = false;
 
-    let insertSnapshotAction: Status | null = null;
-    let currentContext: ContextPayload | null = null;
+    let insertSnapshotAction = null as Status | null;
+    let currentContext = null as ContextPayload | null;
     $: ({ currentOffice } = $dashboardState);
 
     function overflowClickHandler(e: CustomEvent<ContextPayload>) {
@@ -96,8 +96,8 @@
         />
     {/if}
     <Modal title="Insert Snapshot" bind:showModal={showInsertSnapshot}>
-        {#if currentOffice === null || currentContext === null || !showInsertSnapshot}
-            No office selected.
+        {#if insertSnapshotAction === null || currentContext === null || !showInsertSnapshot}
+            Invalid parameters.
         {:else}
             <InsertSnapshot
                 payload={currentContext}

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { Office } from '~model/office';
     import { dashboardState } from '../stores/DashboardState';
     import { documentInbox } from '../stores/DocumentStore';
 
@@ -19,25 +18,17 @@
     let showAcceptContextMenu = false;
     let showInboxContextMenu = false;
 
-    let currentOffice: Office['id'] | null = null;
-
-    let insertSnapshotAction: Status| null = null;
+    let insertSnapshotAction: Status | null = null;
     let currentContext: ContextPayload | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 
     function overflowClickHandler(e: CustomEvent<ContextPayload>) {
-        if (!e.detail) return;
-
         currentContext = e.detail;
-
-        showInboxContextMenu = e.detail.ty === RowType.Inbox;
-        showAcceptContextMenu = e.detail.ty === RowType.AcceptDocument;
+        showInboxContextMenu = currentContext.ty === RowType.Inbox;
+        showAcceptContextMenu = currentContext.ty === RowType.AcceptDocument;
     }
 
     function contextMenuHandler(e: CustomEvent<ContextPayload>) {
-        if (!e.detail) return;
         switch (e.type) {
             case Events.AcceptDocument:
                 insertSnapshotAction = Status.Receive;
@@ -86,8 +77,8 @@
         {#each $documentInbox?.accept as accepted (accepted.doc)}
             <InboxRow
                 {...accepted}
-                iconSize = {IconSize.Large}
-                on:overflowClick = {overflowClickHandler}
+                iconSize={IconSize.Large}
+                on:overflowClick={overflowClickHandler}
             />
         {/each}
     {/if}

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -57,32 +57,28 @@
         Register and Stage a New Document
     </Button>
 
-    <h2>Pending Acceptance</h2>
-    {#if $documentInbox?.pending.length === 0}
-        No incoming documents.
-    {:else}
-        {#each $documentInbox?.pending as pending (pending.doc)}
+    {#await documentInbox.load()}
+        <p>Loading inbox...</p>
+    {:then { pending, accept }}
+        <h2>Pending Acceptance</h2>
+        {#each pending as entry (entry.doc)}
             <AcceptRow
-                {...pending}
+                {...entry}
                 iconSize = {IconSize.Large}
                 on:overflowClick = {overflowClickHandler}
             />
         {/each}
-    {/if}
 
-    <h2>Office Inbox</h2>
-    {#if $documentInbox?.accept.length === 0 }
-        No accepted documents in Inbox
-    {:else}
-        {#each $documentInbox?.accept as accepted (accepted.doc)}
+        <h2>Office Inbox</h2>
+        {#each accept as entry (entry.doc)}
             <InboxRow
-                {...accepted}
+                {...entry}
                 iconSize={IconSize.Large}
                 on:overflowClick={overflowClickHandler}
             />
         {/each}
-    {/if}
-    
+    {/await}
+
     {#if currentContext?.ty === RowType.Inbox}
         <InboxContext bind:show={showInboxContextMenu} payload={currentContext} 
             on:sendDocument={contextMenuHandler}
@@ -107,10 +103,6 @@
         {/if}
     </Modal>
     <Modal title="Create Document" bind:showModal={showCreateDocument}>
-        {#if currentOffice === null }
-            No office selected.
-        {:else}
-            <CreateDocument />
-        {/if}
+        <CreateDocument />
     </Modal>
 {/if}

--- a/client/src/pages/dashboard/views/Invites.svelte
+++ b/client/src/pages/dashboard/views/Invites.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    import { Office } from '~model/office';
+<script>
     import { dashboardState } from '../stores/DashboardState';
 
-    let currentOffice: Office['id'] | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 </script>
 
 {#if currentOffice === null}

--- a/client/src/pages/dashboard/views/Metrics.svelte
+++ b/client/src/pages/dashboard/views/Metrics.svelte
@@ -4,8 +4,7 @@
     import { dashboardState } from '../stores/DashboardState.ts';
     import { userSummary, localSummary, globalSummary } from '../stores/MetricStore.ts';
 
-    // eslint-disable-next-line prefer-destructuring
-    $: currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 
     let metricsMode: 'user' | 'local' | 'global' | undefined;
     let metric: MetricsModel | null = null;

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { Office } from '~model/office';
     import { Status } from '../../../../../model/src/snapshot.ts';
     import { dashboardState } from '../stores/DashboardState';
     import { documentOutbox } from '../stores/DocumentStore';
@@ -13,10 +12,7 @@
     import CreateDocument from '../../../components/ui/forms/document/CreateDocument.svelte';
     import SendRow from '../../../components/ui/itemrow/SendRow.svelte';
 
-    let currentOffice: Office['id'] | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 
     let showContextMenu = false;
     let showInsertSnapshot = false;

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -53,27 +53,24 @@
         Register and Stage a New Document
     </Button>
 
-    <h2>Staged Registered Documents</h2>
-    {#if $documentOutbox?.ready.length === 0 }
-        No staged registered documents.
-    {:else}
-        {#each $documentOutbox?.ready as register (register.doc)}
+    {#await documentOutbox.load()}
+        <p>Loading outbox...</p>
+    {:then { pending, ready }}
+        <h2>Staged Registered Documents</h2>
+        {#each ready as entry (entry.doc)}
             <RegisterRow 
-                {...register}
+                {...entry}
                 iconSize={IconSize.Large} 
                 on:overflowClick = {overflowClickHandler}
             />
         {/each}
-    {/if}
-    <h2>Sent Documents</h2>
-    {#if $documentOutbox?.pending.length === 0 }
-        No documents pending in outbox.
-    {:else}
-        {#each $documentOutbox?.pending as pending (pending.doc)}
-            <SendRow iconSize={IconSize.Large} {...pending} />
+
+        <h2>Sent Documents</h2>
+        {#each pending as entry (entry.doc)}
+            <SendRow iconSize={IconSize.Large} {...entry} />
         {/each}
-    {/if}
-    
+    {/await}
+
     {#if currentContext?.ty === RowType.Inbox}
         <InboxContext
             bind:show={showContextMenu}

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -22,17 +22,15 @@
     let showInsertSnapshot = false;
     let showCreateDocument = false;
 
-    let insertSnapshotAction: Status| null = null;
-    let currentContext: ContextPayload | null = null;
+    let insertSnapshotAction = null as Status | null;
+    let currentContext = null as ContextPayload | null;
 
     function overflowClickHandler(e: CustomEvent<ContextPayload>) {
-        if (!e.detail) return;
         currentContext = e.detail;
         showContextMenu = true;
     }
 
     function contextMenuHandler(e: CustomEvent<ContextPayload>) {
-        if (!e.detail) return;
         switch (e.type) {
             case Events.SendDocument:
                 insertSnapshotAction = Status.Send;
@@ -86,8 +84,8 @@
     {/if}
 
     <Modal title="Insert Snapshot" bind:showModal={showInsertSnapshot}>
-        {#if currentOffice === null || currentContext === null || !showInsertSnapshot}
-            No office selected.
+        {#if insertSnapshotAction === null || currentContext === null || !showInsertSnapshot}
+            Invalid parameters.
         {:else}
             <InsertSnapshot
                 payload={currentContext}
@@ -97,10 +95,6 @@
         {/if}
     </Modal>
     <Modal title="Create Document" bind:showModal={showCreateDocument}>
-        {#if currentOffice === null }
-            No office selected.
-        {:else}
-            <CreateDocument />
-        {/if}
+        <CreateDocument />
     </Modal>
 {/if}

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -41,8 +41,7 @@
     let currentOffice: Office['id'] | null = null;
     let isSubscribed = false;
 
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 
     function handleIsSubscribed(e: CustomEvent<boolean>) {
         isSubscribed = e.detail;

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-    import { Office } from '~model/office';
     import { dashboardState } from '../stores/DashboardState';
 
-    let currentOffice: Office['id'] | null = null;
-
-    // eslint-disable-next-line prefer-destructuring
-    $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+    $: ({ currentOffice } = $dashboardState);
 </script>
 
 {#if currentOffice === null}


### PR DESCRIPTION
This PR was originally an implementation of @justinruaya123's original adaptive title bar, but with reactive statements instead. However, I ended up resolving all non-`alert` and non-`console` lint warnings along the way. Here are some the techniques I used to resolve them:

## `@typescript-eslint/no-unsafe-enum-comparison`
Simply cast the `enum` as a `Number` during runtime.
```diff
- res.status === Status.OK
+ res.status === Number(Status.OK)
```

## `@typescript-eslint/no-unnecessary-condition`
Use an `as`-cast (not a type annotation!) to disallow TypeScript from type-narrowing too aggressively.
```diff
- export let submit = false;
+ export let submit = false as boolean;
```

There were also some warnings on unnecessary optional chaining. Indeed, we did this so that we always check whether an async store contains a value. However, the more idiomatic implementation is to simply `await` the `Loadable` (rather than prefixing the `Loadable` with `$`).
```diff
- {#if $asyncStore?.prop.length === 0}
+ {#await asyncStore.load()}
+     ...
+ {:then { prop }}
+     {#if prop.length === 0}
+         ...
+     {/if}
+ {/await}
```

# `prefer-destructuring`
Simply surround the assignment in parentheses. Note that there is no need to declare the destructured variable with `let` because [Svelte already does this for us](https://svelte.dev/docs#component-format-script-3-$-marks-a-statement-as-reactive) whenever we initialize undeclared variables via reactive statements.
```diff
- $: if ($dashboardState.currentOffice !== null) currentOffice = $dashboardState.currentOffice;
+ $: ({ currentOffice } = $dashboardState);
```