### PR TITLE
feat(client): reinstate generic select components as specializations

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -2,6 +2,12 @@ import { Document } from '../../../model/src/document.ts';
 import { Invitation } from '../../../model/src/invitation.ts';
 import { Staff } from '../../../model/src/staff.ts';
 
+export enum MetricsMode {
+    User,
+    Local,
+    Global,
+}
+
 export enum IconColor {
     Default = 'default',
     White = 'white'

--- a/client/src/components/ui/MetricsSelect.svelte
+++ b/client/src/components/ui/MetricsSelect.svelte
@@ -1,19 +1,12 @@
-<script lang="ts" context="module">
-    export enum Mode {
-        User,
-        Local,
-        Global,
-    }
-</script>
-
 <script lang="ts">
-    export let value: Mode | undefined;
+    import { MetricsMode } from '../types.ts';
+    export let value: MetricsMode | undefined;
 </script>
 
 <select required bind:value>
-    <option value={Mode.User}>User Summary</option>
-    <option value={Mode.Local}>Local Summary</option>
-    <option value={Mode.Global}>Global Summary</option>
+    <option value={MetricsMode.User}>User Summary</option>
+    <option value={MetricsMode.Local}>Local Summary</option>
+    <option value={MetricsMode.Global}>Global Summary</option>
 </select>
 
 <style>

--- a/client/src/components/ui/MetricsSelect.svelte
+++ b/client/src/components/ui/MetricsSelect.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" context="module">
+    export enum Mode {
+        User,
+        Local,
+        Global,
+    }
+</script>
+
+<script lang="ts">
+    export let value: Mode | undefined;
+</script>
+
+<select required bind:value>
+    <option value={Mode.User}>User Summary</option>
+    <option value={Mode.Local}>Local Summary</option>
+    <option value={Mode.Global}>Global Summary</option>
+</select>
+
+<style>
+    select {
+        padding: var(--spacing-small) var(--spacing-normal);
+        border: var(--spacing-tiny) solid var(--shadow-color);
+        border-radius: var(--border-radius);
+        background: var(--dashboard-bg);
+        box-shadow: 0 var(--spacing-tiny) var(--spacing-small) -0.0625em var(--shadow-color);
+        cursor: pointer;
+        font-size: var(--normal);
+        transition: all var(--animation-length) ease;
+    }
+
+    select:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 var(--spacing-tiny) rgba(var(--primary-color), 0.2);
+    }
+</style>

--- a/client/src/components/ui/StatusSelect.svelte
+++ b/client/src/components/ui/StatusSelect.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import { Status } from '~model/snapshot.ts';
+    export let value: number | undefined;
+</script>
+
+<select required bind:value>
+    <option value={Status.Register}>Register</option>
+    <option value={Status.Send}>Send</option>
+    <option value={Status.Receive}>Receive</option>
+    <option value={Status.Terminate}>Terminate</option>
+</select>
+
+<style>
+    select {
+        padding: var(--spacing-small) var(--spacing-normal);
+        border: var(--spacing-tiny) solid var(--shadow-color);
+        border-radius: var(--border-radius);
+        background: var(--dashboard-bg);
+        box-shadow: 0 var(--spacing-tiny) var(--spacing-small) -0.0625em var(--shadow-color);
+        cursor: pointer;
+        font-size: var(--normal);
+        transition: all var(--animation-length) ease;
+    }
+
+    select:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 var(--spacing-tiny) rgba(var(--primary-color), 0.2);
+    }
+</style>

--- a/client/src/components/ui/StatusSelect.svelte
+++ b/client/src/components/ui/StatusSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Status } from '~model/snapshot.ts';
+    import { Status } from '../../../../model/src/snapshot';
     export let value: Status | undefined;
 </script>
 

--- a/client/src/components/ui/StatusSelect.svelte
+++ b/client/src/components/ui/StatusSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Status } from '~model/snapshot.ts';
-    export let value: number | undefined;
+    export let value: Status | undefined;
 </script>
 
 <select required bind:value>

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -55,7 +55,7 @@
     {#if status === Status.Terminate || status === Status.Receive}
         Set Target Office: This Office.
     {:else}
-        Set Target Office: <OfficeSelect offices={$allOffices} bind:oid={destOfficeId}/>
+        Set Target Office: <OfficeSelect offices={$allOffices} bind:oid={destOfficeId} />
     {/if}
     
     <br />

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -9,10 +9,11 @@
     import { documentInbox, documentOutbox } from '../../../../pages/dashboard/stores/DocumentStore.ts';
     import { ContextPayload, IconColor } from '../../../types.ts';
 
-    import OfficeSelect from '../../OfficeSelect.svelte';
-    import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
     import Checkmark from '../../../icons/Checkmark.svelte';
+    import OfficeSelect from '../../OfficeSelect.svelte';
+    import StatusSelect from '../../StatusSelect.svelte';
+    import TextInput from '../../TextInput.svelte';
     
     export let payload: ContextPayload;
     export let userOfficeId: Office['id'];
@@ -31,7 +32,7 @@
         assert(payload.id);
 
         try {
-            await Snapshot.insert( userOfficeId,{
+            await Snapshot.insert(userOfficeId,{
                 doc: payload.id,
                 status,
                 remark: node.value,
@@ -54,17 +55,11 @@
     {#if status === Status.Terminate || status === Status.Receive}
         Set Target Office: This Office.
     {:else}
-        Set Target Office:
-        <OfficeSelect offices={$allOffices} bind:oid={destOfficeId}/>
+        Set Target Office: <OfficeSelect offices={$allOffices} bind:oid={destOfficeId}/>
     {/if}
     
     <br />
-    Set Status As:
-    <select required bind:value={status}>
-        <option value={Status.Send}>Send</option>
-        <option value={Status.Receive}>Receive</option>
-        <option value={Status.Terminate}>Terminate</option>
-    </select>
+    Set Status As: <StatusSelect bind:value={status} />
     <br />
     <TextInput name="snap-remark" label="Remarks: " placeholder="Optional" />
     <Button submit> <Checkmark color={IconColor.White} alt="Submit this Document" /> Submit this Document</Button>

--- a/client/src/pages/dashboard/views/Metrics.svelte
+++ b/client/src/pages/dashboard/views/Metrics.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
     import type { Metrics as MetricsModel } from '~model/metrics.ts';
 
-    import MetricsSelect, { Mode } from '../../../components/ui/MetricsSelect.svelte';
+    import MetricsSelect from '../../../components/ui/MetricsSelect.svelte';
+    import { MetricsMode } from '../../../components/types.ts';
 
     import { dashboardState } from '../stores/DashboardState.ts';
     import { userSummary, localSummary, globalSummary } from '../stores/MetricStore.ts';
 
-    function selectSummary(mode?: Mode): MetricsModel {
+    function selectSummary(mode?: MetricsMode): MetricsModel {
         switch (mode) {
-            case Mode.User: return $userSummary;
-            case Mode.Local: return $localSummary;
-            case Mode.Global: return $globalSummary;
+            case MetricsMode.User: return $userSummary;
+            case MetricsMode.Local: return $localSummary;
+            case MetricsMode.Global: return $globalSummary;
             default: return { };
         }
     }
 
-    let mode: Mode | undefined;
+    let mode: MetricsMode | undefined;
 
     $: ({ currentOffice } = $dashboardState);
     $: metric = selectSummary(mode);

--- a/client/src/pages/dashboard/views/Metrics.svelte
+++ b/client/src/pages/dashboard/views/Metrics.svelte
@@ -1,28 +1,24 @@
 <script lang="ts">
     import type { Metrics as MetricsModel } from '~model/metrics.ts';
 
+    import MetricsSelect, { Mode } from '../../../components/ui/MetricsSelect.svelte';
+
     import { dashboardState } from '../stores/DashboardState.ts';
     import { userSummary, localSummary, globalSummary } from '../stores/MetricStore.ts';
 
-    $: ({ currentOffice } = $dashboardState);
-
-    let metricsMode: 'user' | 'local' | 'global' | undefined;
-    let metric: MetricsModel | null = null;
-
-    $: switch (metricsMode) {
-        case 'user':
-            metric = $userSummary;
-            break;
-        case 'local':
-            metric = $localSummary;
-            break;
-        case 'global':
-            metric = $globalSummary;
-            break;
-        default:
-            metric = null;
-            break;
+    function selectSummary(mode?: Mode): MetricsModel {
+        switch (mode) {
+            case Mode.User: return $userSummary;
+            case Mode.Local: return $localSummary;
+            case Mode.Global: return $globalSummary;
+            default: return { };
+        }
     }
+
+    let mode: Mode | undefined;
+
+    $: ({ currentOffice } = $dashboardState);
+    $: metric = selectSummary(mode);
 </script>
 
 {#if currentOffice === null}
@@ -32,29 +28,24 @@
     <main>
         <div class='header'>
             <h3>Report</h3>
-            <select required bind:value={metricsMode}>
-                <option value="user">User Summary</option>
-                <option value="local">Local Summary</option>
-                <option value="global">Global Summary</option>
-            </select>
+            <MetricsSelect bind:value={mode} />
         </div>
-
         <table>
             <tr>
                 <td>Registered</td>
-                <td>{metric?.Register ?? 0}</td>
+                <td>{metric.Register ?? 0}</td>
             </tr>
             <tr>
                 <td>Sent</td>
-                <td>{metric?.Send ?? 0}</td>
+                <td>{metric.Send ?? 0}</td>
             </tr>
             <tr>
                 <td>Received</td>
-                <td>{metric?.Receive ?? 0}</td>
+                <td>{metric.Receive ?? 0}</td>
             </tr>
             <tr>
                 <td>Tagged as Terminal</td>
-                <td>{metric?.Terminate ?? 0}</td>
+                <td>{metric.Terminate ?? 0}</td>
             </tr>
         </table>
     </main>


### PR DESCRIPTION
In #68, I mistakenly inlined the `Select` component into its raw `<select>` and `<option>` counterparts to "simplify" the markup. It turns out that this had the funny consequence where all selection menus now have the wrong CSS styles.

This PR resolves this issue by reinstating the previously generic `Select` components into the more specialized `MetricsSelect` and `StatusSelect` components.

# Future Work
There is too much duplication of the same CSS `<style>`. At this point, we should just move the `select` and `select:focus` queries into some `global.css`.