### PR TITLE
feat(client): implement chips information display in `RowElementComponent`

### DIFF
--- a/client/src/components/icons/icon-styles.css
+++ b/client/src/components/icons/icon-styles.css
@@ -19,6 +19,6 @@
 }
 
 .large {
-    width: var(--large);
-    height: var(--large);
+    width: var(--x-large);
+    height: var(--x-large);
 }

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -72,6 +72,6 @@ export interface PersonPayload {
 }
 
 export interface GlobalPersonPayload {
-    ty: RowType.Person
-    id: User['id']
+    ty: RowType.Person;
+    id: User['id'];
 }

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -1,6 +1,7 @@
 import { Document } from '../../../model/src/document.ts';
 import { Invitation } from '../../../model/src/invitation.ts';
 import { Staff } from '../../../model/src/staff.ts';
+import { User } from '~model/user.ts';
 
 export enum MetricsMode {
     User,
@@ -50,6 +51,7 @@ export enum Events {
     ShowUserInfo = 'showUserInfo',
     DeleteUser = 'deleteUser',
     EditUser = 'editUser',
+    RowContainerClick = 'rowContainerClick',
 }
 
 export interface ContextPayload {
@@ -67,4 +69,9 @@ export interface PersonPayload {
     ty: RowType.Person;
     id: Staff['user_id'];
     office: Staff['office'];
+}
+
+export interface GlobalPersonPayload {
+    ty: RowType.Person
+    id: User['id']
 }

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -1,7 +1,7 @@
 import { Document } from '../../../model/src/document.ts';
 import { Invitation } from '../../../model/src/invitation.ts';
 import { Staff } from '../../../model/src/staff.ts';
-import { User } from '~model/user.ts';
+import { User } from '../../../model/src/user.ts';
 
 export enum MetricsMode {
     User,

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -41,7 +41,7 @@
     }
 
     #middle {
-        flex: 0 0 auto;
+        flex: 0 1 auto;
     }
 
     .subtext {

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -6,12 +6,12 @@
     import OverflowMenuVertical from '../icons/OverflowMenuVertical.svelte';
 
     export let iconSize: IconSize = IconSize.Large;
-    export let showOverflowIcon: boolean = true;
+    export let showOverflowIcon = true;
 
     const dispatch = createEventDispatcher();
 </script>
 
-<article>
+<article on:keydown on:click|stopPropagation={() => dispatch(Events.RowContainerClick)}>
     <div class="icon"><slot name="icon" /></div>
     <div class="header"><slot/></div>
     <div class="subtext"><slot name="secondary"/></div>

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -6,38 +6,55 @@
     import OverflowMenuVertical from '../icons/OverflowMenuVertical.svelte';
 
     export let iconSize: IconSize = IconSize.Large;
-    export let title: string;
+    export let showOverflowIcon: boolean = true;
 
     const dispatch = createEventDispatcher();
 </script>
 
 <article>
     <div class="icon"><slot name="icon" /></div>
-    <p>{title}</p>
-    <div class="icon" on:keydown on:click|stopPropagation={() => dispatch(Events.OverflowClick)}>
-        <OverflowMenuVertical size={iconSize} alt="Show overflow menu" />
-    </div>
+    <div class="header"><slot/></div>
+    <div class="subtext"><slot name="secondary"/></div>
+    {#if showOverflowIcon}
+        <div class="overflow" on:keydown on:click|stopPropagation={() => dispatch(Events.OverflowClick)}>
+            <OverflowMenuVertical size={iconSize} alt="Show overflow menu" />
+        </div>
+    {/if}
 </article>
 
 <style>
     @import url('../../pages/vars.css');
 
     article {
-        display: flex;
+        display: grid;
         border-style: solid;
         border-width: var(--spacing-tiny);
         border-radius: var(--border-radius);
         margin: var(--spacing-small);
         padding: var(--spacing-small);
-
+        grid-row-gap: var(--spacing-small);
+        justify-content: space-between;
+        grid-template-areas: 
+            "a b b b b b c"
+            "a d d d d d c";
     }
 
     .icon {
-        flex-grow: 0;
+        grid-area: a;
+        align-self: start;
     }
 
-    p {
-        flex-grow: 1;
-        margin: 0;
+    .overflow {
+        grid-area: c;
+        align-self: start;
+    }
+    
+    .header {
+        grid-area: b;
+    }
+
+    .subtext {
+        grid-area: d;
+        font-size: var(--small);
     }
 </style>

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -13,8 +13,10 @@
 
 <article on:keydown on:click|stopPropagation={() => dispatch(Events.RowContainerClick)}>
     <div class="icon"><slot name="icon" /></div>
-    <div class="header"><slot/></div>
-    <div class="subtext"><slot name="secondary"/></div>
+    <div id="middle">
+        <div><slot/></div>
+        <div class="subtext"><slot name="secondary"/></div>
+    </div>
     {#if showOverflowIcon}
         <div class="overflow" on:keydown on:click|stopPropagation={() => dispatch(Events.OverflowClick)}>
             <OverflowMenuVertical size={iconSize} alt="Show overflow menu" />
@@ -26,35 +28,23 @@
     @import url('../../pages/vars.css');
 
     article {
-        display: grid;
+        display: flex;
         border-style: solid;
         border-width: var(--spacing-tiny);
         border-radius: var(--border-radius);
         margin: var(--spacing-small);
         padding: var(--spacing-small);
-        grid-row-gap: var(--spacing-small);
-        justify-content: space-between;
-        grid-template-areas: 
-            "a b b b b b c"
-            "a d d d d d c";
     }
 
-    .icon {
-        grid-area: a;
-        align-self: start;
+    article > div {
+        flex: 0 1 auto;
     }
 
-    .overflow {
-        grid-area: c;
-        align-self: start;
-    }
-    
-    .header {
-        grid-area: b;
+    #middle {
+        flex: 0 0 auto;
     }
 
     .subtext {
-        grid-area: d;
         font-size: var(--small);
     }
 </style>

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -14,8 +14,8 @@
 <article on:keydown on:click|stopPropagation={() => dispatch(Events.RowContainerClick)}>
     <div class="icon"><slot name="icon" /></div>
     <div id="middle">
-        <div><slot/></div>
-        <div class="subtext"><slot name="secondary"/></div>
+        <div><slot></slot></div>
+        <div class="subtext"><slot name="secondary"></slot></div>
     </div>
     {#if showOverflowIcon}
         <div class="overflow" on:keydown on:click|stopPropagation={() => dispatch(Events.OverflowClick)}>

--- a/client/src/components/ui/RowTemplate.svelte
+++ b/client/src/components/ui/RowTemplate.svelte
@@ -41,7 +41,7 @@
     }
 
     #middle {
-        flex: 0 1 auto;
+        flex: 1 0 auto;
     }
 
     .subtext {

--- a/client/src/components/ui/forms/category/ActivateCategory.svelte
+++ b/client/src/components/ui/forms/category/ActivateCategory.svelte
@@ -31,9 +31,9 @@
 <article>
     {#await categoryList.load()}
         Loading list of retired categories...
-    {:then { retire: categories }}
+    {:then}
         <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-            <CategorySelect bind:catId {categories} />
+            <CategorySelect bind:catId categories={$categoryList.retire} />
             <br />
             {#if typeof catId === 'number'}
                 <Button submit><Edit color={IconColor.White} alt="Reactivate Category" /> Reactivate Category</Button>

--- a/client/src/components/ui/forms/category/RemoveCategory.svelte
+++ b/client/src/components/ui/forms/category/RemoveCategory.svelte
@@ -31,9 +31,9 @@
 <article>
     {#await categoryList.load()}
         Loading list of removable categories...
-    {:then { active: categories }}
+    {:then}
         <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-            <CategorySelect bind:catId {categories} />
+            <CategorySelect bind:catId categories={$categoryList.active} />
             <br />
             <Button type={ButtonType.Danger} submit><Close color={IconColor.White} alt="Edit Category" /> Remove Category</Button>
         </form>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -36,8 +36,8 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">Document UUID: {docDisplay}</span>
-        <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
+        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentImport size={iconSize} slot="icon" alt="A pending document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -24,8 +24,6 @@
     function redirectHandler() {
         window.location.href = `/track?id=${doc}`;
     }
-    
-    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
@@ -36,7 +34,7 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentImport size={iconSize} slot="icon" alt="A pending document" />

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -8,7 +8,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
-    import { redirectHandler } from './util.ts';
+    import { goToTrackingPage } from './util.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -26,7 +26,7 @@
 <RowTemplate
     {iconSize}
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={() => redirectHandler(doc)}
+    on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -31,7 +31,7 @@
 <RowTemplate
     {iconSize}
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={ () => redirectHandler()}
+    on:rowContainerClick={redirectHandler}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -8,6 +8,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
+    import { redirectHandler } from './util.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -20,16 +21,12 @@
         ty: RowType.AcceptDocument,
         id: doc,
     };
-
-    function redirectHandler() {
-        window.location.href = `/track?id=${doc}`;
-    }
 </script>
 
 <RowTemplate
     {iconSize}
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={redirectHandler}
+    on:rowContainerClick={() => redirectHandler(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -35,7 +35,7 @@
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip doc">Document UUID: {docDisplay}</span>
         <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
     </span>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -7,23 +7,37 @@
     import { ContextPayload, RowType, IconSize, Events } from '../../types.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
+    import { Snapshot } from '~model/snapshot.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
     export let category: Category['name'];
     export let title: Document['title'];
+    export let creation: Snapshot['creation'];
 
     const dispatch = createEventDispatcher();
     const rowEvent: ContextPayload = {
         ty: RowType.AcceptDocument,
         id: doc,
     };
+
+    function redirectHandler() {
+        window.location.href = `/track?id=${doc}`;
+    }
+    
+    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
-    title={`${title} ID: ${doc} Category: ${category}`}
     {iconSize}
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:rowContainerClick={ () => redirectHandler()}
 >
+    <span class="chip category">{category}</span>
+    <span class="title">{title}</span>
+    <span slot="secondary">
+        <span class="chip doc">Document UUID: {docDisplay}</span>
+        <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
+    </span>
     <DocumentImport size={iconSize} slot="icon" alt="A pending document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -7,23 +7,37 @@
     import { IconSize, ContextPayload, RowType, Events } from '../../types.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
+    import { Snapshot } from '~model/snapshot.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
     export let category: Category['name'];
     export let title: Document['title'];
+    export let creation: Snapshot['creation'];
 
     const dispatch = createEventDispatcher();
     const rowEvent: ContextPayload = {
         ty: RowType.Inbox,
         id: doc,
     };
+
+    function redirectHandler() {
+        window.location.href = `/track?id=${doc}`;
+    }
+    
+    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
-    title={`${title} ID: ${doc} Category: ${category}`}
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:rowContainerClick={ () => redirectHandler()}
 >
+    <span class="chip category">{category}</span>
+    <span class="title">{title}</span>
+    <span slot="secondary">
+        <span class="chip doc">Document UUID: {docDisplay}</span>
+        <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
+    </span>
     <DocumentBlank size={iconSize} slot="icon" alt ="An inbox document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -36,8 +36,8 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">Document UUID: {docDisplay}</span>
-        <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
+        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentBlank size={iconSize} slot="icon" alt ="An inbox document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -8,6 +8,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
+    import { redirectHandler } from './util.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -20,16 +21,12 @@
         ty: RowType.Inbox,
         id: doc,
     };
-
-    function redirectHandler() {
-        window.location.href = `/track?id=${doc}`;
-    }
 </script>
 
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={redirectHandler}
+    on:rowContainerClick={() => redirectHandler(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -35,7 +35,7 @@
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip doc">Document UUID: {docDisplay}</span>
         <span class="chip timestamp">Recieved on: {creation.toLocaleString()}</span>
     </span>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -31,7 +31,7 @@
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={ () => redirectHandler()}
+    on:rowContainerClick={redirectHandler}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -8,7 +8,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
-    import { redirectHandler } from './util.ts';
+    import { goToTrackingPage } from './util.ts';
 
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -26,7 +26,7 @@
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={() => redirectHandler(doc)}
+    on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -24,8 +24,6 @@
     function redirectHandler() {
         window.location.href = `/track?id=${doc}`;
     }
-    
-    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
@@ -36,7 +34,7 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentBlank size={iconSize} slot="icon" alt ="An inbox document" />

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -31,8 +31,8 @@
     <span class="title">{email}</span>
     <span slot="secondary" class="chipcontainer">
         <span class="chip permission">Permission: {permission.toString(2).padStart(9, '0')}</span>
-        <span class="chip target">Invite to: {targetName}</span>
-        <span class="chip timestamp">Created on: {creation.toLocaleString()}</span>
+        <span class="chip target">{targetName}</span>
+        <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <PersonMail size={iconSize} slot="icon" alt="An invited person" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -6,6 +6,7 @@
 
     import { IconSize, InvitePayload, RowType, Events } from '../../types.ts';
     import { Invitation } from '../../../../../model/src/invitation.ts';
+    import { Office } from '~model/office.ts';
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
     export let iconSize: IconSize;
 
@@ -14,6 +15,7 @@
     export let email: Invitation['email'];
     export let permission: Invitation['permission'];
     export let creation: Invitation['creation'];
+    let targetName: Office['name'];
     
     const dispatch = createEventDispatcher();
     const rowEvent: InvitePayload = {
@@ -22,7 +24,7 @@
         office,
     };
 
-    const targetName = $allOffices[office] ?? 'No office.';
+    $: targetName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -18,8 +18,8 @@
     const dispatch = createEventDispatcher();
     const rowEvent: InvitePayload = {
         ty: RowType.Invite,
-        email: email,
-        office: office,
+        email,
+        office,
     };
 
     const targetName = $allOffices[office] ?? 'No office.';

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -6,6 +6,7 @@
 
     import { IconSize, InvitePayload, RowType, Events } from '../../types.ts';
     import { Invitation } from '../../../../../model/src/invitation.ts';
+    import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
     export let iconSize: IconSize;
 
     // From invitation.ts
@@ -20,12 +21,18 @@
         email: email,
         office: office,
     };
+
+    const targetName = office ? $allOffices[office] : '';
 </script>
 
 <RowTemplate
-    title={`${email} Office: ${office} Permission: ${permission} Created on: ${creation.toDateString()}`}
-    {iconSize}
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
 >
+    <span class="title">{email}</span>
+    <span slot="secondary">
+        <span class="chip permission">Permission: {permission.toString(2).padStart(9, '0')}</span>
+        <span class="chip target">Invite to: {targetName}</span>
+        <span class="chip timestamp">Created on: {creation.toLocaleString()}</span>
+    </span>
     <PersonMail size={iconSize} slot="icon" alt="An invited person" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -29,7 +29,7 @@
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
 >
     <span class="title">{email}</span>
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip permission">Permission: {permission.toString(2).padStart(9, '0')}</span>
         <span class="chip target">Invite to: {targetName}</span>
         <span class="chip timestamp">Created on: {creation.toLocaleString()}</span>

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -22,7 +22,7 @@
         office: office,
     };
 
-    const targetName = office ? $allOffices[office] : '';
+    const targetName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -33,5 +33,5 @@
         <span class="chip doc">User ID: {id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(9, '0')}</span>
     </span>
-    <img class={iconSize} src={picture} alt={name} slot="icon" />
+    <img class="{iconSize} rounded" src={picture} alt={name} slot="icon" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -28,7 +28,7 @@
 >
     <span class="chip office">Operator</span>
     <span class="title">{name}</span>    
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip email">User Email: {email}</span>
         <span class="chip doc">User ID: {id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(9, '0')}</span>

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -4,9 +4,8 @@
 
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { PersonPayload, IconSize, Events, RowType } from '../../types.ts';
+    import { GlobalPersonPayload, IconSize, Events, RowType } from '../../types.ts';
     import { User } from '../../../../../model/src/user.ts';
-    import { Staff } from '../../../../../model/src/staff.ts';
     export let iconSize: IconSize;
     
     // From user.ts
@@ -14,30 +13,25 @@
     export let name: User['name'];
     export let email: User['email'];
     export let picture: User['picture'];
-    export let globalPermission: User['permission'];
-
-    // From staff.ts
-    export let office: Staff['office'];
-    export let localPermission: Staff['permission'];
+    export let permission: User['permission'];
 
     const dispatch = createEventDispatcher();
-    const rowEvent: PersonPayload = {
+    const rowEvent: GlobalPersonPayload = {
         ty: RowType.Person,
         id,
-        office,
     };
 </script>
 
 <RowTemplate 
-    title={`${name} ID: ${id} Email: ${email} Office: ${office} Global Perms: ${globalPermission} Local Perms: ${localPermission}`}
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
 >
+    <span class="chip office">Operator</span>
+    <span class="title">{name}</span>    
+    <span slot="secondary">
+        <span class="chip email">User Email: {email}</span>
+        <span class="chip doc">User ID: {id}</span>
+        <span class="chip permission">Permissions: {permission.toString(2).padStart(9, '0')}</span>
+    </span>
     <img class={iconSize} src={picture} alt={name} slot="icon" />
 </RowTemplate>
-
-<style>
-    img {
-        border-radius: 50%;
-    }
-</style>

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -29,8 +29,8 @@
     <span class="chip office">Operator</span>
     <span class="title">{name}</span>    
     <span slot="secondary" class="chipcontainer">
-        <span class="chip email">User Email: {email}</span>
-        <span class="chip doc">User ID: {id}</span>
+        <span class="chip email">{email}</span>
+        <span class="chip doc">#{id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(9, '0')}</span>
     </span>
     <img class="{iconSize} rounded" src={picture} alt={name} slot="icon" />

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -41,5 +41,5 @@
         <span class="chip doc">User ID: {id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(12, '0')}</span>
     </span>
-    <img class={iconSize} src={picture} alt={name} slot="icon" />
+    <img class="{iconSize} rounded" src={picture} alt={name} slot="icon" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import './row-element.css';
+    import { createEventDispatcher } from 'svelte';
+
+    import RowTemplate from '../RowTemplate.svelte';
+
+    import { PersonPayload, IconSize, Events, RowType } from '../../types.ts';
+    import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
+    import { User } from '../../../../../model/src/user.ts';
+    import { Staff } from '../../../../../model/src/staff.ts';
+    export let iconSize: IconSize;
+    
+    // From user.ts
+    export let id: User['id'];
+    export let name: User['name'];
+    export let email: User['email'];
+    export let picture: User['picture'];
+
+    // From staff.ts
+    export let office: Staff['office'];
+    export let permission: Staff['permission'];
+
+    const dispatch = createEventDispatcher();
+    const rowEvent: PersonPayload = {
+        ty: RowType.Person,
+        id,
+        office,
+    };
+
+    const officeName = office ? $allOffices[office] : '';
+</script>
+
+<RowTemplate 
+    {iconSize} 
+    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+>
+    <span class="chip office">{officeName}</span>
+    <span class="title">{name}</span>    
+    <span slot="secondary">
+        <span class="chip email">User Email: {email}</span>
+        <span class="chip doc">User ID: {id}</span>
+        <span class="chip permission">Permissions: {permission.toString(2).padStart(12, '0')}</span>
+    </span>
+    <img class={iconSize} src={picture} alt={name} slot="icon" />
+</RowTemplate>

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -28,8 +28,6 @@
         id,
         office,
     };
-
-    let officeName: Office['name'];
     
     $: officeName = $allOffices[office] ?? 'No office.';
 </script>

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -37,8 +37,8 @@
     <span class="chip office">{officeName}</span>
     <span class="title">{name}</span>    
     <span slot="secondary" class="chipcontainer">
-        <span class="chip email">User Email: {email}</span>
-        <span class="chip doc">User ID: {id}</span>
+        <span class="chip email">{email}</span>
+        <span class="chip doc">#{id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(12, '0')}</span>
     </span>
     <img class="{iconSize} rounded" src={picture} alt={name} slot="icon" />

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -36,7 +36,7 @@
 >
     <span class="chip office">{officeName}</span>
     <span class="title">{name}</span>    
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip email">User Email: {email}</span>
         <span class="chip doc">User ID: {id}</span>
         <span class="chip permission">Permissions: {permission.toString(2).padStart(12, '0')}</span>

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -8,6 +8,8 @@
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
     import { User } from '../../../../../model/src/user.ts';
     import { Staff } from '../../../../../model/src/staff.ts';
+    import { Office } from '~model/office.ts';
+    
     export let iconSize: IconSize;
     
     // From user.ts
@@ -27,7 +29,9 @@
         office,
     };
 
-    const officeName = $allOffices[office] ?? 'No office.';
+    let officeName: Office['name'];
+    
+    $: officeName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate 

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -27,7 +27,7 @@
         office,
     };
 
-    const officeName = office ? $allOffices[office] : '';
+    const officeName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate 

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -35,5 +35,5 @@
         <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
-    <DocumentBlank size={iconSize} slot="icon" alt ="A registered document" />
+    <DocumentBlank size={iconSize} slot="icon" alt="A registered document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -32,7 +32,7 @@
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={ () => redirectHandler()}
+    on:rowContainerClick={redirectHandler}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -9,7 +9,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
-    import { redirectHandler } from './util.ts';
+    import { goToTrackingPage } from './util.ts';
     
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -27,7 +27,7 @@
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={() => redirectHandler(doc)}
+    on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -35,5 +35,5 @@
         <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
-    <DocumentBlank size={iconSize} slot="icon" alt ="An registered document" />
+    <DocumentBlank size={iconSize} slot="icon" alt ="A registered document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -36,7 +36,7 @@
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip doc">Document UUID: {docDisplay}</span>
         <span class="chip timestamp">Registered on: {creation.toLocaleString()}</span>
     </span>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -25,8 +25,6 @@
     function redirectHandler() {
         window.location.href = `/track?id=${doc}`;
     }
-    
-    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
@@ -37,7 +35,7 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentBlank size={iconSize} slot="icon" alt ="An registered document" />

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -9,6 +9,7 @@
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';
+    import { redirectHandler } from './util.ts';
     
     export let iconSize: IconSize;
     export let doc: Document['id'];
@@ -21,16 +22,12 @@
         ty: RowType.Inbox,
         id: doc,
     };
-
-    function redirectHandler() {
-        window.location.href = `/track?id=${doc}`;
-    }
 </script>
 
 <RowTemplate
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
-    on:rowContainerClick={redirectHandler}
+    on:rowContainerClick={() => redirectHandler(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import './chip-style.css';
     import { createEventDispatcher } from 'svelte';
 
     import DocumentBlank from '../../icons/DocumentBlank.svelte';
@@ -7,23 +8,37 @@
     import { IconSize, RowType, ContextPayload, Events } from '../../types.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
+    import { Snapshot } from '~model/snapshot.ts';
     
     export let iconSize: IconSize;
     export let doc: Document['id'];
     export let category: Category['name'];
     export let title: Document['title'];
-
+    export let creation: Snapshot['creation'];
+    
     const dispatch = createEventDispatcher();
     const rowEvent: ContextPayload = {
         ty: RowType.Inbox,
         id: doc,
     };
+
+    function redirectHandler() {
+        window.location.href = `/track?id=${doc}`;
+    }
+    
+    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate
-    title={`${title} ID: ${doc} Category: ${category}`}
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:rowContainerClick={ () => redirectHandler()}
 >
-    <DocumentBlank size={iconSize} slot="icon" alt ="An sent document" />
+    <span class="chip category">{category}</span>
+    <span class="title">{title}</span>
+    <span slot="secondary">
+        <span class="chip doc">Document UUID: {docDisplay}</span>
+        <span class="chip timestamp">Registered on: {creation.toLocaleString()}</span>
+    </span>
+    <DocumentBlank size={iconSize} slot="icon" alt ="An registered document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -37,8 +37,8 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">Document UUID: {docDisplay}</span>
-        <span class="chip timestamp">Registered on: {creation.toLocaleString()}</span>
+        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip timestamp">{creation.toLocaleString()}</span>
     </span>
     <DocumentBlank size={iconSize} slot="icon" alt ="An registered document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -27,8 +27,8 @@
     const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
-<RowTemplate {iconSize} showOverflowIcon = {false}
-    on:rowContainerClick={ () => redirectHandler()}
+<RowTemplate {iconSize} showOverflowIcon={false}
+    on:rowContainerClick={redirectHandler}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -20,8 +20,9 @@
     export let title: Document['title'];
     export let target: Office['id'];
     export let creation: Snapshot['creation'];
-
-    const targetName = $allOffices[target] ?? 'No office.';
+    let targetName: Office['name'];
+    
+    $: targetName = $allOffices[target] ?? 'No office.';
 </script>
 
 <RowTemplate {iconSize} showOverflowIcon={false}

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -33,8 +33,8 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">Document UUID: {docDisplay}</span>
-        <span class="chip timestamp">Sent on: {creation.toLocaleString()}</span>
+        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip timestamp">{creation.toLocaleString()}</span>
         <span class="chip target">Sent to: {targetName}</span>
     </span>
     <DocumentExport size={iconSize} slot="icon" alt ="An sent document" />

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -24,7 +24,6 @@
     }
 
     const targetName = target ? $allOffices[target] : '';
-    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
 <RowTemplate {iconSize} showOverflowIcon={false}
@@ -33,7 +32,7 @@
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
     <span slot="secondary" class="chipcontainer">
-        <span class="chip doc">#{docDisplay}</span>
+        <span class="chip doc">#{doc}</span>
         <span class="chip timestamp">{creation.toLocaleString()}</span>
         <span class="chip target">Sent to: {targetName}</span>
     </span>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -32,7 +32,7 @@
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>
-    <span slot="secondary">
+    <span slot="secondary" class="chipcontainer">
         <span class="chip doc">Document UUID: {docDisplay}</span>
         <span class="chip timestamp">Sent on: {creation.toLocaleString()}</span>
         <span class="chip target">Sent to: {targetName}</span>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -5,7 +5,7 @@
     import type { Category } from '~model/category.ts';
     import type { Snapshot } from '~model/snapshot.ts';
     import type { Office } from '~model/office.ts';
-    import { redirectHandler } from './util.ts';
+    import { goToTrackingPage } from './util.ts';
 
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
 
@@ -26,7 +26,7 @@
 </script>
 
 <RowTemplate {iconSize} showOverflowIcon={false}
-    on:rowContainerClick={() => redirectHandler(doc)}
+    on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -5,6 +5,7 @@
     import type { Category } from '~model/category.ts';
     import type { Snapshot } from '~model/snapshot.ts';
     import type { Office } from '~model/office.ts';
+    import { redirectHandler } from './util.ts';
 
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
 
@@ -20,15 +21,11 @@
     export let target: Office['id'];
     export let creation: Snapshot['creation'];
 
-    function redirectHandler() {
-        window.location.href = `/track?id=${doc}`;
-    }
-
     const targetName = $allOffices[target] ?? 'No office.';
 </script>
 
 <RowTemplate {iconSize} showOverflowIcon={false}
-    on:rowContainerClick={redirectHandler}
+    on:rowContainerClick={() => redirectHandler(doc)}
 >
     <span class="chip category">{category}</span>
     <span class="title">{title}</span>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -4,6 +4,7 @@
     import type { Document } from '~model/document.ts';
     import type { Category } from '~model/category.ts';
     import type { Snapshot } from '~model/snapshot.ts';
+    import type { Office } from '~model/office.ts';
 
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
 
@@ -16,14 +17,14 @@
     export let doc: Document['id'];
     export let category: Category['name'];
     export let title: Document['title'];
-    export let target: Snapshot['target'];
+    export let target: Office['id'];
     export let creation: Snapshot['creation'];
 
     function redirectHandler() {
         window.location.href = `/track?id=${doc}`;
     }
 
-    const targetName = target ? $allOffices[target] : '';
+    const targetName = $allOffices[target] ?? 'No office.';
 </script>
 
 <RowTemplate {iconSize} showOverflowIcon={false}

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -20,7 +20,6 @@
     export let title: Document['title'];
     export let target: Office['id'];
     export let creation: Snapshot['creation'];
-    let targetName: Office['name'];
     
     $: targetName = $allOffices[target] ?? 'No office.';
 </script>

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+    import './chip-style.css';
+
     import type { Document } from '~model/document.ts';
     import type { Category } from '~model/category.ts';
     import type { Snapshot } from '~model/snapshot.ts';
+
+    import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
 
     import DocumentExport from '../../icons/DocumentExport.svelte';
     import RowTemplate from '../RowTemplate.svelte';
@@ -13,8 +17,25 @@
     export let category: Category['name'];
     export let title: Document['title'];
     export let target: Snapshot['target'];
+    export let creation: Snapshot['creation'];
+
+    function redirectHandler() {
+        window.location.href = `/track?id=${doc}`;
+    }
+
+    const targetName = target ? $allOffices[target] : '';
+    const docDisplay = `${doc.slice(0,5)}...${doc.slice(-5)}`;
 </script>
 
-<RowTemplate {iconSize} title={`${title} ID: ${doc} Category: ${category} Sent to Office: ${target ?? 0}`}>
+<RowTemplate {iconSize} showOverflowIcon = {false}
+    on:rowContainerClick={ () => redirectHandler()}
+>
+    <span class="chip category">{category}</span>
+    <span class="title">{title}</span>
+    <span slot="secondary">
+        <span class="chip doc">Document UUID: {docDisplay}</span>
+        <span class="chip timestamp">Sent on: {creation.toLocaleString()}</span>
+        <span class="chip target">Sent to: {targetName}</span>
+    </span>
     <DocumentExport size={iconSize} slot="icon" alt ="An sent document" />
 </RowTemplate>

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -11,6 +11,7 @@ img .rounded {
 .chip {
     border-radius: var(--border-radius);
     padding: var(--spacing-tiny) var(--spacing-normal) var(--spacing-tiny) var(--spacing-normal);
+    text-overflow: ellipsis;
 }
 
 span > span {

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -1,0 +1,28 @@
+@import url(../../../pages/vars.css);
+
+.title {
+    font-weight: bolder;
+}
+.chip {
+    border-radius: var(--border-radius);
+    padding: var(--spacing-tiny) var(--spacing-normal) var(--spacing-tiny) var(--spacing-normal);
+}
+
+.doc {
+    border: solid var(--secondary-color) var(--spacing-tiny);
+    background-color: var(--gray-color);
+}
+
+.category {
+    background-color: var(--primary-color);
+    font-style: bold;
+    color: white;
+}
+
+.target {
+    border: solid red 1px;
+}
+
+.timestamp {
+    border: solid orange 1px;
+}

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -1,6 +1,6 @@
 @import url(../../../pages/vars.css);
 
-img {
+img .rounded {
     border-radius: 50%;
 }
 

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -1,5 +1,9 @@
 @import url(../../../pages/vars.css);
 
+img {
+    border-radius: 50%;
+}
+
 .title {
     font-weight: bolder;
 }
@@ -20,9 +24,21 @@
 }
 
 .target {
-    border: solid red 1px;
+    border: solid orangered 1px;
 }
 
 .timestamp {
     border: solid orange 1px;
+}
+
+.office {
+    border: solid olivedrab 1px;
+}
+
+.permission {
+    border: solid violet 1px;
+}
+
+.email {
+    border: solid brown 1px
 }

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -14,12 +14,14 @@ img .rounded {
 }
 
 span > span {
-    display: block;
+    display: inline-block;
+    flex: 0 0 content;
 }
 
 .chipcontainer {
     display: flex;
     flex-wrap: wrap;
+    gap: var(--spacing-small);
 }
 
 .doc {

--- a/client/src/components/ui/itemrow/chip-style.css
+++ b/client/src/components/ui/itemrow/chip-style.css
@@ -7,9 +7,19 @@ img .rounded {
 .title {
     font-weight: bolder;
 }
+
 .chip {
     border-radius: var(--border-radius);
     padding: var(--spacing-tiny) var(--spacing-normal) var(--spacing-tiny) var(--spacing-normal);
+}
+
+span > span {
+    display: block;
+}
+
+.chipcontainer {
+    display: flex;
+    flex-wrap: wrap;
 }
 
 .doc {

--- a/client/src/components/ui/itemrow/util.ts
+++ b/client/src/components/ui/itemrow/util.ts
@@ -1,0 +1,5 @@
+import { Document } from '~model/document';
+
+export function redirectHandler(id: Document['id']) {
+    window.location.href = `/track?id=${id}`;
+}

--- a/client/src/components/ui/itemrow/util.ts
+++ b/client/src/components/ui/itemrow/util.ts
@@ -1,5 +1,5 @@
 import { Document } from '~model/document';
 
-export function redirectHandler(id: Document['id']) {
+export function goToTrackingPage(id: Document['id']) {
     window.location.href = `/track?id=${id}`;
 }

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -59,9 +59,9 @@
 
     {#await documentInbox.load()}
         <p>Loading inbox...</p>
-    {:then { pending, accept }}
+    {:then}
         <h2>Pending Acceptance</h2>
-        {#each pending as entry (entry.doc)}
+        {#each $documentInbox.pending as entry (entry.doc)}
             <AcceptRow
                 {...entry}
                 iconSize = {IconSize.Large}
@@ -70,7 +70,7 @@
         {/each}
 
         <h2>Office Inbox</h2>
-        {#each accept as entry (entry.doc)}
+        {#each $documentInbox.accept as entry (entry.doc)}
             <InboxRow
                 {...entry}
                 iconSize={IconSize.Large}

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -51,9 +51,9 @@
 
     {#await documentOutbox.load()}
         <p>Loading outbox...</p>
-    {:then { pending, ready }}
+    {:then}
         <h2>Staged Registered Documents</h2>
-        {#each ready as entry (entry.doc)}
+        {#each $documentOutbox.ready as entry (entry.doc)}
             <RegisterRow 
                 {...entry}
                 iconSize={IconSize.Large} 
@@ -62,7 +62,7 @@
         {/each}
 
         <h2>Sent Documents</h2>
-        {#each pending as entry (entry.doc)}
+        {#each $documentOutbox.pending as entry (entry.doc)}
             <SendRow iconSize={IconSize.Large} {...entry} />
         {/each}
     {/await}

--- a/client/src/pages/vars.css
+++ b/client/src/pages/vars.css
@@ -11,7 +11,7 @@
 
     --text-color: #000000;
     --font-size: 16px;
-    --x-large: 2rem;
+    --x-large: 2.5rem;
     --large: 1.5rem;
     --medium: 1.25rem;
     --normal: 1rem;


### PR DESCRIPTION
This PR aims to change the respective `RowElementComponents` to a grid layout and a chip based design to display relevant information.
1. Change inner `RowElement` layout to a grid.
2. Use chips to display relevant `RowElement` information.
3. Stage redirect to redirect the `RowElement` to the respective tracking page.
**Hotfix**
1. Revert Inbox/Outbox RowElement enumerators to read from the store rather than the result of the `await load` operation.
2. 
![opera_ladynDd6Ay](https://user-images.githubusercontent.com/22850026/235395690-2810a61c-61e2-4994-ab15-16d250f11b87.gif)
