### PR TITLE
feat(client): implement notification request helper

### DIFF
--- a/client/src/notification.ts
+++ b/client/src/notification.ts
@@ -1,0 +1,13 @@
+/** Attempts to send a notification. Repeatedly prompts the user until they explicitly accept or reject. */
+export async function sendNotification(title: string, options?: NotificationOptions) {
+    let perm = Notification.permission;
+    do {
+        switch (perm) {
+            case 'granted': return new Notification(title, options);
+            case 'denied': return null;
+            case 'default':
+            default: break;
+        }
+        perm = await Notification.requestPermission();
+    } while (true);
+}

--- a/client/src/notification.ts
+++ b/client/src/notification.ts
@@ -1,7 +1,6 @@
 /** Attempts to send a notification. Repeatedly prompts the user until they explicitly accept or reject. */
 export async function sendNotification(title: string, options?: NotificationOptions) {
     let perm = Notification.permission;
-
     for (;;) {
         switch (perm) {
             case 'granted': return new Notification(title, options);

--- a/client/src/notification.ts
+++ b/client/src/notification.ts
@@ -1,7 +1,8 @@
 /** Attempts to send a notification. Repeatedly prompts the user until they explicitly accept or reject. */
 export async function sendNotification(title: string, options?: NotificationOptions) {
     let perm = Notification.permission;
-    do {
+
+    for (;;) {
         switch (perm) {
             case 'granted': return new Notification(title, options);
             case 'denied': return null;
@@ -9,5 +10,5 @@ export async function sendNotification(title: string, options?: NotificationOpti
             default: break;
         }
         perm = await Notification.requestPermission();
-    } while (true);
+    }
 }


### PR DESCRIPTION
This PR implements the `sendNotification` helper function. It essentially keeps looping until the user explicitly _grants_ or _denies_ permissions.