### PR TITLE
feat(client): implementation of staffs subpage

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -48,10 +48,9 @@ export enum Events {
     TerminateDocument = 'terminateDocument',
     CreateInvitation = 'createInvitation',
     RemoveInvitation = 'removeInvitation',
-    ShowUserInfo = 'showUserInfo',
-    DeleteUser = 'deleteUser',
-    EditUser = 'editUser',
     RowContainerClick = 'rowContainerClick',
+    EditLocalPermission = 'editLocalPermission',
+    RemoveStaff = 'removeStaff'
 }
 
 export interface ContextPayload {
@@ -69,6 +68,8 @@ export interface PersonPayload {
     ty: RowType.Person;
     id: Staff['user_id'];
     office: Staff['office'];
+    email: User['email'];
+    permission: Staff['permission'];
 }
 
 export interface GlobalPersonPayload {

--- a/client/src/components/ui/contextdrawer/PersonContext.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContext.svelte
@@ -17,24 +17,17 @@
 </script>
 
 <ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.ShowUserInfo, payload)}>
+    <ContextElement on:click={() => dispatch(Events.EditLocalPermission, payload)}>
         <div slot="contextIcon">
-            <Search size={iconSize} alt="View User Details" />
-            View User Details
+            <Edit size={iconSize} alt="Edit Local Permissions" />
+            Edit Local Permissions
         </div>
     </ContextElement>
     <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.EditUser, payload)}>
+    <ContextElement on:click={() => dispatch(Events.RemoveStaff, payload)}>
         <div slot="contextIcon">
-            <Edit size={iconSize} alt="Edit User Details" />
-            Edit User Details
-        </div>
-    </ContextElement>
-    <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.DeleteUser, payload)}>
-        <div slot="contextIcon">
-            <Close size={iconSize} alt="Delete User" />
-            Delete User
+            <Close size={iconSize} alt="Remove Staff" />
+            Remove Staff
         </div>
     </ContextElement>
 </ContextTemplate>

--- a/client/src/components/ui/contextdrawer/PersonContext.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContext.svelte
@@ -6,9 +6,8 @@
     import ContextElement from '../contextmenu/ContextElement.svelte';
     import ContextDivider from '../contextmenu/ContextDivider.svelte';
 
-    import Search from '../../icons/Search.svelte';
     import Edit from '../../icons/Edit.svelte';
-    import Close from '../../icons/Close.svelte';
+    import PersonDelete from '../../icons/PersonDelete.svelte'
 
     const dispatch = createEventDispatcher();
     export let show = false;
@@ -26,7 +25,7 @@
     <ContextDivider />
     <ContextElement on:click={() => dispatch(Events.RemoveStaff, payload)}>
         <div slot="contextIcon">
-            <Close size={iconSize} alt="Remove Staff" />
+            <PersonDelete size={iconSize} alt="Remove Staff" />
             Remove Staff
         </div>
     </ContextElement>

--- a/client/src/components/ui/contextdrawer/PersonContext.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContext.svelte
@@ -7,7 +7,7 @@
     import ContextDivider from '../contextmenu/ContextDivider.svelte';
 
     import Edit from '../../icons/Edit.svelte';
-    import PersonDelete from '../../icons/PersonDelete.svelte'
+    import PersonDelete from '../../icons/PersonDelete.svelte';
 
     const dispatch = createEventDispatcher();
     export let show = false;

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -3,9 +3,10 @@
     import { assert } from '../../../../assert.ts';
     import { IconColor, PersonPayload } from '../../../types.ts';
     import { Staff } from '../../../../api/staff.ts';
-
     import { Local } from '../../../../../../model/src/permission.ts';
+
     import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
+    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
@@ -43,7 +44,7 @@
         }
     }
 </script>
-<p>You are modifying {payload.email}'s permissions in Office ID {payload.office}.</p>
+<p>You are modifying {payload.email}'s permissions in {$allOffices[payload.office]}.</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <label>
         <input

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
-    import { IconColor } from '../../../types.ts';
+    import { IconColor, PersonPayload } from '../../../types.ts';
     import { Staff } from '../../../../api/staff.ts';
 
     import { Local } from '../../../../../../model/src/permission.ts';
-    import type { User as UserModel } from '../../../../../../model/src/user.ts';
-
-    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
+    import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 
-    export let user: UserModel;
-    export let office: number;
+    export let payload: PersonPayload;
 
     async function handleSubmit(this: HTMLFormElement) {
         // Recompute permissions before submitting
@@ -28,32 +25,32 @@
         });
 
         // No point in handling no-changes.
-        if (user.permission === permsVal) return;
+        if (payload.permission === permsVal) return;
 
         try {
             // Rebuild pseudo-user object
             await Staff.setPermission({
-                office,
-                user_id: user.id,
+                office: payload.office,
+                user_id: payload.id,
                 permission: permsVal,
             });
 
-            // Might be editing own session, might be not, reload anyway
-            await userSession.reload?.();
+            // Reload the staffList store
+            await staffList.reload?.();
         } catch (err) {
             // TODO: No permission handler
             alert(err);
         }
     }
 </script>
-<p>You are modifying {user.email}'s permissions in Office ID {office}.</p>
+<p>You are modifying {payload.email}'s permissions in Office ID {payload.office}.</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <label>
         <input
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={checkPerms(user.permission, Local.AddStaff)}
+            checked={checkPerms(payload.permission, Local.AddStaff)}
         />
         Add Staff
     </label>
@@ -62,7 +59,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={checkPerms(user.permission, Local.RemoveStaff)}
+            checked={checkPerms(payload.permission, Local.RemoveStaff)}
         />
         Remove Staff
     </label>
@@ -71,7 +68,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={checkPerms(user.permission, Local.UpdateStaff)}
+            checked={checkPerms(payload.permission, Local.UpdateStaff)}
         />
         Update Staff
     </label>
@@ -80,7 +77,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={checkPerms(user.permission, Local.AddInvite)}
+            checked={checkPerms(payload.permission, Local.AddInvite)}
         />
         Add Invite
     </label>
@@ -89,7 +86,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={checkPerms(user.permission, Local.RevokeInvite)}
+            checked={checkPerms(payload.permission, Local.RevokeInvite)}
         />
         Revoke Invite
     </label>
@@ -98,7 +95,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={checkPerms(user.permission, Local.ViewBatch)}
+            checked={checkPerms(payload.permission, Local.ViewBatch)}
         />
         View Batch
     </label>
@@ -107,7 +104,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={checkPerms(user.permission, Local.GenerateBatch)}
+            checked={checkPerms(payload.permission, Local.GenerateBatch)}
         />
         Generate Batch
     </label>
@@ -116,7 +113,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={checkPerms(user.permission, Local.InvalidateBatch)}
+            checked={checkPerms(payload.permission, Local.InvalidateBatch)}
         />
         Invalidate Batch
     </label>
@@ -125,7 +122,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={checkPerms(user.permission, Local.CreateDocument)}
+            checked={checkPerms(payload.permission, Local.CreateDocument)}
         />
         Create Document
     </label>
@@ -134,7 +131,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={checkPerms(user.permission, Local.InsertSnapshot)}
+            checked={checkPerms(payload.permission, Local.InsertSnapshot)}
         />
         Insert Snapshot
     </label>
@@ -143,7 +140,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={checkPerms(user.permission, Local.ViewMetrics)}
+            checked={checkPerms(payload.permission, Local.ViewMetrics)}
         />
         View Metrics
     </label>
@@ -152,7 +149,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={checkPerms(user.permission, Local.ViewInbox)}
+            checked={checkPerms(payload.permission, Local.ViewInbox)}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import { Staff } from '../../../../api/staff.ts'; 
+    import { PersonPayload } from '../../../types.ts';
+    import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
+    
+    import Button from '../../Button.svelte';
+    import PersonDelete from '../../../icons/PersonDelete.svelte';
+    import { ButtonType, IconColor } from '../../../types.ts';
+
+    export let payload: PersonPayload;
+
+    async function handleRemove() {
+        try{
+            await Staff.remove({
+                office: payload.office,
+                user_id: payload.id,
+            });
+            await staffList.reload?.();
+        } catch (err) {
+            // TODO: No permission handler
+            alert(err);
+        }
+    }
+</script>
+
+
+<p>Are you sure you want to remove {payload.email} from {payload.office}?</p>
+<Button type={ButtonType.Danger} on:click={handleRemove}>
+    <PersonDelete color={IconColor.White} alt="Remove Staff" on:click/>Remove Staff
+</Button>

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Staff } from '../../../../api/staff.ts';
     import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
+    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
     
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
@@ -23,7 +24,7 @@
 </script>
 
 
-<p>Are you sure you want to remove {payload.email} from {payload.office}?</p>
+<p>Are you sure you want to remove {payload.email} from {$allOffices[payload.office]}?</p>
 <Button type={ButtonType.Danger} on:click={handleRemove}>
     <PersonDelete color={IconColor.White} alt="Remove Staff" on:click/>Remove Staff
 </Button>

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
-    import { Staff } from '../../../../api/staff.ts'; 
-    import { PersonPayload } from '../../../types.ts';
+    import { Staff } from '../../../../api/staff.ts';
     import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
     
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
-    import { ButtonType, IconColor } from '../../../types.ts';
+    import { ButtonType, IconColor, PersonPayload } from '../../../types.ts';
 
     export let payload: PersonPayload;
 
     async function handleRemove() {
-        try{
+        try {
             await Staff.remove({
                 office: payload.office,
                 user_id: payload.id,

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import './row-element.css';
+    // import './row-element.css';
+    import './chip-style.css';
     import { createEventDispatcher } from 'svelte';
 
     import RowTemplate from '../RowTemplate.svelte';
@@ -27,6 +28,8 @@
         ty: RowType.Person,
         id,
         office,
+        email,
+        permission,
     };
     
     $: officeName = $allOffices[office] ?? 'No office.';

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    // import './row-element.css';
     import './chip-style.css';
     import { createEventDispatcher } from 'svelte';
 

--- a/client/src/pages/dashboard/stores/StaffStore.ts
+++ b/client/src/pages/dashboard/stores/StaffStore.ts
@@ -1,0 +1,14 @@
+import { asyncDerived } from '@square/svelte-store';
+import { dashboardState } from './DashboardState.ts';
+import { Staff } from '../../../api/staff.ts';
+
+export const staffList = asyncDerived(
+    dashboardState,
+    $dashboardState => {
+        const { currentOffice } = $dashboardState;
+        return currentOffice === null
+            ? Promise.resolve([])
+            : Staff.get(currentOffice);
+    },
+    { reloadable: true }
+);

--- a/client/src/pages/dashboard/views/Invites.svelte
+++ b/client/src/pages/dashboard/views/Invites.svelte
@@ -23,7 +23,6 @@
         currentContext = e.detail;
         showRevokeInviteContextMenu = currentContext.ty === RowType.Invite;
     }
-
 </script>
 
 {#if currentOffice === null}
@@ -43,7 +42,7 @@
     {#await inviteList.load()}
         Loading invite list.
     {:then}
-        {#if $inviteList.length === 0 || currentOffice !== null}
+        {#if $inviteList.length === 0 || currentOffice === null}
                 <h3>No invite backlogs, yay!</h3>
         {:else}
             {#each $inviteList as { email, permission, creation } (email)}

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -9,7 +9,6 @@
     import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
     import NewOffice from '../../../components/ui/forms/office/NewOffice.svelte';
     import EditOffice from '../../../components/ui/forms/office/EditOffice.svelte';
-    import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import CreateCategory from '../../../components/ui/forms/category/CreateCategory.svelte';
     import RenameCategory from '../../../components/ui/forms/category/RenameCategory.svelte';
     import RemoveCategory from '../../../components/ui/forms/category/RemoveCategory.svelte';
@@ -22,7 +21,6 @@
 
     let showCreateOffice = false;
     let showEditOffice = false;
-    let showLocalPermission = false;
     let showPermission = false;
     let showCreateCategory = false;
     let showEditCategory = false;
@@ -52,9 +50,6 @@
 </Button>
 <Button on:click={() => (showEditOffice = true)}>
     Edit an Office
-</Button>
-<Button on:click={() => (showLocalPermission = true)} disabled={Object.getOwnPropertyNames($allOffices).length === 0}>
-    Edit Local Permission
 </Button>
 <Button on:click={() => (showCreateCategory = true)}>
     Create a Category
@@ -107,14 +102,6 @@
 </Modal>
 <Modal title="Create a Category" bind:showModal={showCreateCategory}>
     <CreateCategory />
-</Modal>
-
-<Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
-    {#if currentOffice === null || $currentUser === null}
-        Current user is not a staff of the selected office.
-    {:else}
-        <LocalPermissions user={$currentUser} office={currentOffice} />
-    {/if}
 </Modal>
 
 <Modal title="Edit Global Permissions" bind:showModal={showPermission}>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import { dashboardState } from '../stores/DashboardState';
-    import { currentUser } from '../stores/UserStore';
     import { staffList } from '../stores/StaffStore';
 
     import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
+    import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import PersonContext from '../../../components/ui/contextdrawer/PersonContext.svelte';
 
@@ -13,6 +13,7 @@
 
     let showContextMenu = false;
     let showLocalPermission = false;
+    let showRemoveStaff = false;
     let currentContext = null as PersonPayload | null;
 
     function overflowClickHandler(e: CustomEvent<PersonPayload>) {
@@ -26,14 +27,10 @@
                 showLocalPermission = true;
                 break;
             case Events.RemoveStaff:
-                // To implement modal for confirming removing staff
+                showRemoveStaff = true;
                 break;
             default: break;
         }
-    }
-
-    async function handleRemoveStaff() {
-        await 
     }
 </script>
 
@@ -48,12 +45,15 @@
             No staff belonging in Office {currentOffice}
         {:else}
             {#each $staffList as staff}
-            <PersonRowLocal
-                {...staff}
-                office={currentOffice}
-                iconSize={IconSize.Large} 
-                on:overflowClick={overflowClickHandler} 
-            />
+                <!--Filtering removed staff-->
+                {#if staff.permission !== 0}
+                <PersonRowLocal
+                    {...staff}
+                    office={currentOffice}
+                    iconSize={IconSize.Large} 
+                    on:overflowClick={overflowClickHandler} 
+                />
+                {/if}
             {/each}
         {/if}
     {/await}
@@ -72,6 +72,14 @@
             Current user is not a staff of the selected office.
         {:else}
             <LocalPermissions payload={currentContext} />
+        {/if}
+    </Modal>
+
+    <Modal title="Remove Staff" bind:showModal={showRemoveStaff}>
+        {#if currentContext === null}
+            Current user is not a staff of the selected office.
+        {:else}
+            <RemoveStaff payload={currentContext} />
         {/if}
     </Modal>
 

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { dashboardState } from '../stores/DashboardState';
     import { staffList } from '../stores/StaffStore';
+    import { allOffices } from '../stores/OfficeStore';
 
     import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
@@ -10,6 +11,7 @@
     import PersonContext from '../../../components/ui/contextdrawer/PersonContext.svelte';
 
     $: ({ currentOffice } = $dashboardState);
+    $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
     let showContextMenu = false;
     let showLocalPermission = false;
@@ -40,9 +42,9 @@
     {#await staffList.load()}
         <p>Loading staff page...</p>
     {:then}
-        <h1>Staffs of Office {currentOffice}</h1>
+        <h1>Staffs of {officeName}</h1>
         {#if staffList === null}
-            No staff belonging in Office {currentOffice}
+            No staff belonging in {officeName}
         {:else}
             {#each $staffList as staff}
                 <!--Filtering removed staff-->

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -1,12 +1,78 @@
 <script lang="ts">
     import { dashboardState } from '../stores/DashboardState';
+    import { currentUser } from '../stores/UserStore';
+    import { staffList } from '../stores/StaffStore';
+
+    import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
+    import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
+    import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
+    import Modal from '../../../components/ui/Modal.svelte';
+    import PersonContext from '../../../components/ui/contextdrawer/PersonContext.svelte';
 
     $: ({ currentOffice } = $dashboardState);
+
+    let showContextMenu = false;
+    let showLocalPermission = false;
+    let currentContext = null as PersonPayload | null;
+
+    function overflowClickHandler(e: CustomEvent<PersonPayload>) {
+        currentContext = e.detail;
+        showContextMenu = true;
+    }
+
+    function contextMenuHandler(e: CustomEvent<PersonPayload>) {
+        switch (e.type) {
+            case Events.EditLocalPermission:
+                showLocalPermission = true;
+                break;
+            case Events.RemoveStaff:
+                // To implement modal for confirming removing staff
+                break;
+            default: break;
+        }
+    }
+
+    async function handleRemoveStaff() {
+        await 
+    }
 </script>
 
 {#if currentOffice === null}
     You must select an office before accessing the Staff page.
 {:else}
-    Staff page of Office ID {currentOffice}.
-    <h1>Staff</h1>
+    {#await staffList.load()}
+        <p>Loading staff page...</p>
+    {:then}
+        <h1>Staffs of Office {currentOffice}</h1>
+        {#if staffList === null}
+            No staff belonging in Office {currentOffice}
+        {:else}
+            {#each $staffList as staff}
+            <PersonRowLocal
+                {...staff}
+                office={currentOffice}
+                iconSize={IconSize.Large} 
+                on:overflowClick={overflowClickHandler} 
+            />
+            {/each}
+        {/if}
+    {/await}
+
+    {#if currentContext?.ty === RowType.Person}
+        <PersonContext
+            bind:show={showContextMenu}
+            payload={currentContext} 
+            on:editLocalPermission={contextMenuHandler}
+            on:removeStaff={contextMenuHandler}
+        />
+    {/if}
+
+    <Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
+        {#if currentContext === null}
+            Current user is not a staff of the selected office.
+        {:else}
+            <LocalPermissions payload={currentContext} />
+        {/if}
+    </Modal>
+
 {/if}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -43,7 +43,7 @@
         <p>Loading staff page...</p>
     {:then}
         <h1>Staffs of {officeName}</h1>
-        {#if staffList === null}
+        {#if $staffList === null}
             No staff belonging in {officeName}
         {:else}
             {#each $staffList as staff}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -84,5 +84,4 @@
             <RemoveStaff payload={currentContext} />
         {/if}
     </Modal>
-
 {/if}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -47,14 +47,14 @@
             No staff belonging in {officeName}
         {:else}
             {#each $staffList as staff}
-                <!--Filtering removed staff-->
+                <!-- Filtering removed staff -->
                 {#if staff.permission !== 0}
-                <PersonRowLocal
-                    {...staff}
-                    office={currentOffice}
-                    iconSize={IconSize.Large} 
-                    on:overflowClick={overflowClickHandler} 
-                />
+                    <PersonRowLocal
+                        {...staff}
+                        office={currentOffice}
+                        iconSize={IconSize.Large} 
+                        on:overflowClick={overflowClickHandler} 
+                    />
                 {/if}
             {/each}
         {/if}


### PR DESCRIPTION
This pull request aims to:

- Add store `staffList`
- Remove `EditLocalPermission` from `Sandbox`
- Change the argument of `EditLocalPermission` from seprate `Office` and `User` to a `PersonPayload`
- Handle `EditLocalPermission` and `RemoveStaff` in `Staff` subpage

Note: `pnpm lint` results to `HeapError` in local machine. Will do linting based on the checks here.