### PR TITLE
feat(server): implement users getter endpoint

### DIFF
--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -11,7 +11,7 @@ import {
 } from './error.ts';
 
 export namespace User {
-    export async function getUsers(): Promise<UserType[]> {
+    export async function getAll(): Promise<UserType[]> {
         const res = await fetch('/api/users', {
             credentials: 'same-origin',
             headers: { 'Accepts': 'application/json' },

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { type User as UserType, UserSchema } from '~model/user.ts';
+import { type User as UserType, UserSchema } from '../../../model/src/user.ts';
 
 import {
     InsufficientPermissions,

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import type { User as UserType } from '~model/user.ts';
+import { type User as UserType, UserSchema } from '~model/user.ts';
 
 import {
     InsufficientPermissions,
@@ -11,6 +11,20 @@ import {
 } from './error.ts';
 
 export namespace User {
+    export async function getUsers(): Promise<UserType[]> {
+        const res = await fetch('/api/users', {
+            credentials: 'same-origin',
+            headers: { 'Accepts': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return UserSchema.array().parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
     export async function setPermission({ id, permission }: Pick<UserType, 'id' | 'permission'>): Promise<boolean> {
         const res = await fetch(`/api/user?perms=${permission}`, {
             credentials: 'same-origin',

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -150,6 +150,7 @@ Deno.test('full OAuth flow', async t => {
             }), null);
 
             assertEquals(await db.getStaff(invite.office), [ { ...USER, permission: invite.permission } ]);
+            assertArrayIncludes(await db.getUsers(), [ { ...USER, permission: 0 } ]);
         });
     });
 

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -547,6 +547,16 @@ export class Database {
         }
     }
 
+    async getUsers(): Promise<User[]> {
+        // TODO: Add Tests
+        const { rows } = await this.#client
+            .queryObject('SELECT id,name,email,picture,permission FROM users');
+        return UserSchema
+            .extend({ permission: z.string().transform(p => parseInt(p, 2)) })
+            .array()
+            .parse(rows);
+    }
+
     /** Returns the user associated with the valid session ID. */
     async getUserFromSession(sid: Session['id']): Promise<User | null> {
         const { rows: [ first, ...rest ] } = await this.#client

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -21,7 +21,7 @@ import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './a
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
 import { handleGetStaff, handleSetStaffPermissions, handleRemoveStaff } from './api/staff.ts';
-import { handleSetUserPermissions } from './api/user.ts';
+import { handleGetUsers, handleSetUserPermissions } from './api/user.ts';
 import { handleSubscribe, handleVapidPublicKey } from './api/vapid.ts';
 import { handleCallback, handleLogin, handleLogout } from './auth/mod.ts';
 
@@ -43,6 +43,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/offices': return handleGetAllOffices(pool, req);
         case '/api/session': return handleGetUserFromSession(pool, req);
         case '/api/staffs': return handleGetStaff(pool, req, searchParams);
+        case '/api/users': return handleGetUsers(pool, req);
         case '/api/vapid': return handleVapidPublicKey();
         case '/auth/login': return handleLogin(pool, req);
         case '/auth/callback': return handleCallback(pool, req, searchParams);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -127,12 +127,14 @@ Deno.test('full API integration test', async t => {
     });
 
     // Promote as superuser
-    await t.step('User API', async () =>
+    await t.step('User API', async () => {
+        assertArrayIncludes(await User.getAll(), [ { ...user, permission: 511 } ]);
         assert(await User.setPermission({
             id: user.id,
             permission: 511,
-        }))
-    );
+        }));
+        assertArrayIncludes(await User.getAll(), [ { ...user, permission: 511 } ]);
+    });
 
     const otherOid = await Office.create('Test Office');
     await t.step('Office API', async () => {


### PR DESCRIPTION
As required by @Arukuen's sprint goals, this PR implements the `GET /api/users` endpoint, which returns an array of all the `User` instances in the system.

# Future Considerations
```ts
// In the future, we may want to turn `User[]` into a `UsersRecord` instead.
type UsersRecord = Record<User['id'], Omit<User, 'id'>>;
```
```ts
// Note that reloading the current user should imply reloading the full user registry.
allUsers.reload?.();
currentUser.reload?.();
```