### PR TITLE
feat(client): implementation of Users subpage

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -50,6 +50,7 @@ export enum Events {
     RemoveInvitation = 'removeInvitation',
     RowContainerClick = 'rowContainerClick',
     EditLocalPermission = 'editLocalPermission',
+    EditGlobalPermission = 'editGlobalPermission',
     RemoveStaff = 'removeStaff'
 }
 
@@ -75,4 +76,6 @@ export interface PersonPayload {
 export interface GlobalPersonPayload {
     ty: RowType.Person;
     id: User['id'];
+    email: User['email'];
+    permission: Staff['permission'];
 }

--- a/client/src/components/ui/contextdrawer/InviteContext.svelte
+++ b/client/src/components/ui/contextdrawer/InviteContext.svelte
@@ -4,7 +4,6 @@
     import { Events, InvitePayload, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
-    import ContextDivider from '../contextmenu/ContextDivider.svelte';
 
     import Close from '../../icons/Close.svelte';
 

--- a/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
@@ -10,7 +10,7 @@
     import PersonDelete from '../../icons/PersonDelete.svelte';
 
     const dispatch = createEventDispatcher();
-    export let show = false;
+    export let show = false as boolean;
     export let payload: PersonPayload;
     export let iconSize = IconSize.Normal;
 </script>

--- a/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
@@ -4,10 +4,8 @@
     import { Events, PersonPayload, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
-    import ContextDivider from '../contextmenu/ContextDivider.svelte';
 
     import Edit from '../../icons/Edit.svelte';
-    import PersonDelete from '../../icons/PersonDelete.svelte';
 
     const dispatch = createEventDispatcher();
     export let show = false as boolean;

--- a/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
@@ -16,17 +16,10 @@
 </script>
 
 <ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.EditLocalPermission, payload)}>
+    <ContextElement on:click={() => dispatch(Events.EditGlobalPermission, payload)}>
         <div slot="contextIcon">
             <Edit size={iconSize} alt="Edit Local Permissions" />
-            Edit Local Permissions
-        </div>
-    </ContextElement>
-    <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.RemoveStaff, payload)}>
-        <div slot="contextIcon">
-            <PersonDelete size={iconSize} alt="Remove Staff" />
-            Remove Staff
+            Edit Global Permissions
         </div>
     </ContextElement>
 </ContextTemplate>

--- a/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+
+    import { Events, PersonPayload, IconSize } from '../../types.ts';
+    import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
+    import ContextElement from '../contextmenu/ContextElement.svelte';
+    import ContextDivider from '../contextmenu/ContextDivider.svelte';
+
+    import Edit from '../../icons/Edit.svelte';
+    import PersonDelete from '../../icons/PersonDelete.svelte';
+
+    const dispatch = createEventDispatcher();
+    export let show = false;
+    export let payload: PersonPayload;
+    export let iconSize = IconSize.Normal;
+</script>
+
+<ContextTemplate bind:show={show}>
+    <ContextElement on:click={() => dispatch(Events.EditLocalPermission, payload)}>
+        <div slot="contextIcon">
+            <Edit size={iconSize} alt="Edit Local Permissions" />
+            Edit Local Permissions
+        </div>
+    </ContextElement>
+    <ContextDivider />
+    <ContextElement on:click={() => dispatch(Events.RemoveStaff, payload)}>
+        <div slot="contextIcon">
+            <PersonDelete size={iconSize} alt="Remove Staff" />
+            Remove Staff
+        </div>
+    </ContextElement>
+</ContextTemplate>

--- a/client/src/components/ui/forms/office/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/office/RevokeInvite.svelte
@@ -6,23 +6,18 @@
     import { Invite } from '../../../../api/invite.ts';
     import { inviteList } from '../../../../pages/dashboard/stores/InviteStore.ts';
     import { ButtonType, IconColor } from '../../../types.ts';
-    import { createEventDispatcher } from 'svelte';
 
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
-    import Close from '../../../icons/Close.svelte';
 
     export let email: Invitation['email'];
     export let office: Office['id'];
 
     $: officeName = $allOffices[office] ?? 'No office name.';
 
-    const dispatch = createEventDispatcher();
-
     async function removeInviteHandler() {
-        assert(email !== null);
-        assert(office !== null);
-
+        assert(email);
+        assert(office);
         try {
             await Invite.revoke({
                 office,

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -5,12 +5,11 @@
     import { User } from '../../../../api/user.ts';
     import { PersonPayload } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
-    import { userSession, userOffices } from '../../../../pages/dashboard/stores/UserStore.ts';
     import { IconColor } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
-  import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
+    import { userList } from '../../../../pages/dashboard/stores/UserStore.ts';
 
     export let payload: PersonPayload;
 
@@ -35,7 +34,7 @@
                 id: payload.id,
                 permission: permsVal,
             });
-            await staffList.reload?.();
+            await userList.reload?.();
         } catch (err) {
             // TODO: No permission handler
             alert(err);

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -3,15 +3,16 @@
     import { assert } from '../../../../assert.ts';
 
     import { User } from '../../../../api/user.ts';
-    import type { User as UserModel } from '../../../../../../model/src/user.ts';
+    import { PersonPayload } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
-    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
+    import { userSession, userOffices } from '../../../../pages/dashboard/stores/UserStore.ts';
     import { IconColor } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
+  import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
 
-    export let user: UserModel;
+    export let payload: PersonPayload;
 
     async function handleSubmit(this: HTMLFormElement) {
         // Recompute permissions before submitting
@@ -26,15 +27,15 @@
         });
 
         // No point in handling no-changes.
-        if (user.permission === permsVal) return;
+        if (payload.permission === permsVal) return;
 
         try {
             // Rebuild pseudo-user object
             await User.setPermission({
-                id: user.id,
+                id: payload.id,
                 permission: permsVal,
             });
-            await userSession.reload?.();
+            await staffList.reload?.();
         } catch (err) {
             // TODO: No permission handler
             alert(err);
@@ -43,13 +44,13 @@
 </script>
 
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-    <p>User ID: {user.id}</p>
+    <p>User ID: {payload.id}</p>
     <label>
         <input
             type="checkbox"
             name="perms"
             value={Global.GetOffices}
-            checked={checkPerms(user.permission, Global.GetOffices)}
+            checked={checkPerms(payload.permission, Global.GetOffices)}
         />
         Get Offices
     </label>
@@ -58,7 +59,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateOffice}
-            checked={checkPerms(user.permission, Global.CreateOffice)}
+            checked={checkPerms(payload.permission, Global.CreateOffice)}
         />
         Create Office
     </label>
@@ -67,7 +68,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateOffice}
-            checked={checkPerms(user.permission, Global.UpdateOffice)}
+            checked={checkPerms(payload.permission, Global.UpdateOffice)}
         />
         Update Office
     </label>
@@ -76,7 +77,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateUser}
-            checked={checkPerms(user.permission, Global.UpdateUser)}
+            checked={checkPerms(payload.permission, Global.UpdateUser)}
         />
         Update User
     </label>
@@ -85,7 +86,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateCategory}
-            checked={checkPerms(user.permission, Global.CreateCategory)}
+            checked={checkPerms(payload.permission, Global.CreateCategory)}
         />
         Create Category
     </label>
@@ -94,7 +95,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateCategory}
-            checked={checkPerms(user.permission, Global.UpdateCategory)}
+            checked={checkPerms(payload.permission, Global.UpdateCategory)}
         />
         Update Category
     </label>
@@ -103,7 +104,7 @@
             type="checkbox"
             name="perms"
             value={Global.DeleteCategory}
-            checked={checkPerms(user.permission, Global.DeleteCategory)}
+            checked={checkPerms(payload.permission, Global.DeleteCategory)}
         />
         Delete Category
     </label>
@@ -112,7 +113,7 @@
             type="checkbox"
             name="perms"
             value={Global.ActivateCategory}
-            checked={checkPerms(user.permission, Global.ActivateCategory)}
+            checked={checkPerms(payload.permission, Global.ActivateCategory)}
         />
         Activate Category
     </label>
@@ -121,7 +122,7 @@
             type="checkbox"
             name="perms"
             value={Global.ViewMetrics}
-            checked={checkPerms(user.permission, Global.ViewMetrics)}
+            checked={checkPerms(payload.permission, Global.ViewMetrics)}
         />
         View Metrics
     </label>

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -3,9 +3,8 @@
     import { assert } from '../../../../assert.ts';
 
     import { User } from '../../../../api/user.ts';
-    import { PersonPayload } from '../../../types.ts';
+    import { PersonPayload, IconColor } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
-    import { IconColor } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import './row-element.css';
     import { createEventDispatcher } from 'svelte';
 
     import RowTemplate from '../RowTemplate.svelte';
@@ -19,6 +18,8 @@
     const rowEvent: GlobalPersonPayload = {
         ty: RowType.Person,
         id,
+        email,
+        permission,
     };
 </script>
 
@@ -26,7 +27,7 @@
     {iconSize} 
     on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
 >
-    <span class="chip office">Operator</span>
+    <span class="chip office">User</span>
     <span class="title">{name}</span>    
     <span slot="secondary" class="chipcontainer">
         <span class="chip email">{email}</span>

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -8,7 +8,6 @@
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
     import { User } from '../../../../../model/src/user.ts';
     import { Staff } from '../../../../../model/src/staff.ts';
-    import { Office } from '~model/office.ts';
     
     export let iconSize: IconSize;
     

--- a/client/src/components/ui/navigationbar/SideDrawer.svelte
+++ b/client/src/components/ui/navigationbar/SideDrawer.svelte
@@ -36,7 +36,7 @@
         <a href="#/barcodes" use:active><BarcodesIcon />Barcodes</a>
         <a href="#/invites" use:active><InvitesIcon />Invites</a>
         <a href="#/staff" use:active><StaffIcon />Staff</a>
-        <a href="#/admin" use:active><AdminIcon />Admin</a>
+        <a href="#/users" use:active><AdminIcon />Users</a>
         <a href="#/settings" use:active><SettingsIcon />Settings</a>
         <a href="#/sandbox" use:active><SettingsIcon />Sandbox</a>
     </section>

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -2,7 +2,8 @@ import { asyncReadable, derived } from '@square/svelte-store';
 
 import { allOffices } from './OfficeStore.ts';
 import { Session } from '../../../api/session.ts';
-import { User } from '~model/user.ts';
+import { User as UserModel } from '~model/user.ts';
+import { User } from '../../../api/user.ts';
 
 export const userSession = asyncReadable(
     null,
@@ -16,7 +17,13 @@ export const currentUser = derived(userSession, session => session === null ? nu
     email: session.email,
     picture: session.picture,
     permission: session.global_perms,
-} as User);
+} as UserModel);
+
+export const userList = asyncReadable(
+    [],
+    User.getAll,
+    { reloadable: true }
+);
 
 export const userOffices = derived([userSession, allOffices], ([$userSession, $allOffices]) => {
     function* iterator() {

--- a/client/src/pages/dashboard/views/Admins.svelte
+++ b/client/src/pages/dashboard/views/Admins.svelte
@@ -1,1 +1,0 @@
-<p>Manage Admins!</p>

--- a/client/src/pages/dashboard/views/Invites.svelte
+++ b/client/src/pages/dashboard/views/Invites.svelte
@@ -21,7 +21,7 @@
 
     function overflowClickHandler(e: CustomEvent<InvitePayload>) {
         currentContext = e.detail;
-        showRevokeInviteContextMenu = currentContext.ty === RowType.Invite;
+        showRevokeInviteContextMenu = true;
     }
 </script>
 

--- a/client/src/pages/dashboard/views/Sandbox.svelte
+++ b/client/src/pages/dashboard/views/Sandbox.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
     import { Office } from '~model/office';
     import { dashboardState } from '../stores/DashboardState';
-    import { currentUser } from '../stores/UserStore.ts';
-    import { allOffices } from '../stores/OfficeStore.ts';
 
     import Modal from '../../../components/ui/Modal.svelte';
     import Button from '../../../components/ui/Button.svelte';
-    import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
     import NewOffice from '../../../components/ui/forms/office/NewOffice.svelte';
     import EditOffice from '../../../components/ui/forms/office/EditOffice.svelte';
     import CreateCategory from '../../../components/ui/forms/category/CreateCategory.svelte';
@@ -21,7 +18,6 @@
 
     let showCreateOffice = false;
     let showEditOffice = false;
-    let showPermission = false;
     let showCreateCategory = false;
     let showEditCategory = false;
     let showRemoveCategory = false;
@@ -42,9 +38,6 @@
 </script>
 
 <h1>Sandbox</h1>
-<Button on:click={() => (showPermission = true)}>
-    Edit Global Permissions
-</Button>
 <Button on:click={() => (showCreateOffice = true)}>
     Create an Office
 </Button>
@@ -104,14 +97,6 @@
     <CreateCategory />
 </Modal>
 
-<Modal title="Edit Global Permissions" bind:showModal={showPermission}>
-    {#if $currentUser === null}
-        Current user is not valid.
-    {:else}
-        <GlobalPermissions user={$currentUser} />
-    {/if}
-</Modal>
-
 <Modal title="Create New Office" bind:showModal={showCreateOffice}>
     <NewOffice />
 </Modal>
@@ -119,7 +104,6 @@
 <Modal title="Edit Office" bind:showModal={showEditOffice}>
     <EditOffice />
 </Modal>
-
 
 <Modal title="Subscribe to Push Notification" bind:showModal={showSubscribePushNotification}>
     <SubscribePushNotification on:subscribe={handleIsSubscribed} />

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -43,21 +43,16 @@
         <p>Loading staff page...</p>
     {:then}
         <h1>Staffs of {officeName}</h1>
-        {#if $staffList === null}
-            No staff belonging in {officeName}
+        {#each $staffList.filter(s => s.permission !== 0) as staff (staff.id)}
+            <PersonRowLocal
+                {...staff}
+                office={currentOffice}
+                iconSize={IconSize.Large} 
+                on:overflowClick={overflowClickHandler} 
+            />
         {:else}
-            {#each $staffList as staff}
-                <!-- Filtering removed staff -->
-                {#if staff.permission !== 0}
-                    <PersonRowLocal
-                        {...staff}
-                        office={currentOffice}
-                        iconSize={IconSize.Large} 
-                        on:overflowClick={overflowClickHandler} 
-                    />
-                {/if}
-            {/each}
-        {/if}
+            No staff members exist.
+        {/each}
     {/await}
 
     {#if currentContext?.ty === RowType.Person}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -8,7 +8,7 @@
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
-    import PersonContext from '../../../components/ui/contextdrawer/PersonContext.svelte';
+    import PersonContextLocal from '../../../components/ui/contextdrawer/PersonContextLocal.svelte';
 
     $: ({ currentOffice } = $dashboardState);
     $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
@@ -61,7 +61,7 @@
     {/await}
 
     {#if currentContext?.ty === RowType.Person}
-        <PersonContext
+        <PersonContextLocal
             bind:show={showContextMenu}
             payload={currentContext} 
             on:editLocalPermission={contextMenuHandler}

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -1,73 +1,70 @@
 <script lang="ts">
-  import { dashboardState } from '../stores/DashboardState';
-  import { staffList } from '../stores/StaffStore';
-  import { allOffices } from '../stores/OfficeStore';
+    import { dashboardState } from '../stores/DashboardState';
+    import { userList } from '../stores/UserStore';
+    import { allOffices } from '../stores/OfficeStore';
 
-  import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
-  import PersonRowGlobal from '../../../components/ui/itemrow/PersonRowGlobal.svelte';
-  import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
-  import Modal from '../../../components/ui/Modal.svelte';
-  import PersonContextGlobal from '../../../components/ui/contextdrawer/PersonContextGlobal.svelte';
+    import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
+    import PersonRowGlobal from '../../../components/ui/itemrow/PersonRowGlobal.svelte';
+    import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
+    import Modal from '../../../components/ui/Modal.svelte';
+    import PersonContextGlobal from '../../../components/ui/contextdrawer/PersonContextGlobal.svelte';
 
-  $: ({ currentOffice } = $dashboardState);
-  $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
+    $: ({ currentOffice } = $dashboardState);
+    $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
-  let showContextMenu = false;
-  let showGlobalPermission = false;
-  let currentContext = null as PersonPayload | null;
+    let showContextMenu = false;
+    let showGlobalPermission = false;
+    let currentContext = null as PersonPayload | null;
 
-  function overflowClickHandler(e: CustomEvent<PersonPayload>) {
+    function overflowClickHandler(e: CustomEvent<PersonPayload>) {
         currentContext = e.detail;
         showContextMenu = true;
-  }
+    }
 
-  function contextMenuHandler(e: CustomEvent<PersonPayload>) {
+    function contextMenuHandler(e: CustomEvent<PersonPayload>) {
         switch (e.type) {
             case Events.EditGlobalPermission:
                 showGlobalPermission = true;
                 break;
             default: break;
         }
-  }
+    }
 </script>
 
-{#if currentOffice === null}
-    You must select an office before accessing the Users page.
+{#await userList.load()}
+    <p>Loading users page...</p>
+{:then}
+    <h1>Users</h1>
+    {#if $userList.length === 0}
+        No users exist
     {:else}
-    {#await staffList.load()}
-        <p>Loading users page...</p>
-    {:then}
-        <h1>Users of {officeName}</h1>
-        {#if $staffList === null}
-            No users belonging in {officeName}
-        {:else}
-            {#each $staffList as staff}
-                <!-- Filtering removed staff -->
-                {#if staff.permission !== 0}
-                    <PersonRowGlobal
-                        {...staff}
-                        iconSize={IconSize.Large} 
-                        on:overflowClick={overflowClickHandler} 
-                    />
-                {/if}
-            {/each}
-        {/if}
-    {/await}
-
-    {#if currentContext?.ty === RowType.Person}
-        <PersonContextGlobal
-            bind:show={showContextMenu}
-            payload={currentContext} 
-            on:editGlobalPermission={contextMenuHandler}
-            on:removeStaff={contextMenuHandler}
-        />
+        {#each $userList as user}
+            <!-- Filtering removed users -->
+            {#if user.permission !== 0}
+                <PersonRowGlobal
+                    {...user}
+                    iconSize={IconSize.Large} 
+                    on:overflowClick={overflowClickHandler} 
+                />
+            {/if}
+        {/each}
     {/if}
+{/await}
 
-    <Modal title="Edit Global Permissions" bind:showModal={showGlobalPermission}>
-        {#if currentContext === null}
-            Current user is not a staff of the selected office.
-        {:else}
-            <GlobalPermissions payload={currentContext} />
-        {/if}
-    </Modal>
+{#if currentContext?.ty === RowType.Person}
+    <PersonContextGlobal
+        bind:show={showContextMenu}
+        payload={currentContext} 
+        on:editGlobalPermission={contextMenuHandler}
+        on:removeStaff={contextMenuHandler}
+    />
 {/if}
+
+<Modal title="Edit Global Permissions" bind:showModal={showGlobalPermission}>
+    {#if currentContext === null}
+        Current user is non existent
+    {:else}
+        <GlobalPermissions payload={currentContext} />
+    {/if}
+</Modal>
+

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -30,20 +30,15 @@
     <p>Loading users page...</p>
 {:then}
     <h1>Users</h1>
-    {#if $userList.length === 0}
-        No users exist
+    {#each $userList.filter(u => u.permission !== 0) as user (user.id)}
+        <PersonRowGlobal
+            {...user}
+            iconSize={IconSize.Large} 
+            on:overflowClick={overflowClickHandler} 
+        />
     {:else}
-        {#each $userList as user}
-            <!-- Filtering removed users -->
-            {#if user.permission !== 0}
-                <PersonRowGlobal
-                    {...user}
-                    iconSize={IconSize.Large} 
-                    on:overflowClick={overflowClickHandler} 
-                />
-            {/if}
-        {/each}
-    {/if}
+        No users exist.
+    {/each}
 {/await}
 
 {#if currentContext?.ty === RowType.Person}

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { dashboardState } from '../stores/DashboardState';
+  import { staffList } from '../stores/StaffStore';
+  import { allOffices } from '../stores/OfficeStore';
+
+  import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
+  import PersonRowGlobal from '../../../components/ui/itemrow/PersonRowGlobal.svelte';
+  import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
+  import Modal from '../../../components/ui/Modal.svelte';
+  import PersonContextGlobal from '../../../components/ui/contextdrawer/PersonContextGlobal.svelte';
+
+  $: ({ currentOffice } = $dashboardState);
+  $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
+
+  let showContextMenu = false;
+  let showGlobalPermission = false;
+  let currentContext = null as PersonPayload | null;
+
+  function overflowClickHandler(e: CustomEvent<PersonPayload>) {
+        currentContext = e.detail;
+        showContextMenu = true;
+  }
+
+  function contextMenuHandler(e: CustomEvent<PersonPayload>) {
+        switch (e.type) {
+            case Events.EditGlobalPermission:
+                showGlobalPermission = true;
+                break;
+            default: break;
+        }
+  }
+</script>
+
+{#if currentOffice === null}
+    You must select an office before accessing the Users page.
+    {:else}
+    {#await staffList.load()}
+        <p>Loading users page...</p>
+    {:then}
+        <h1>Users of {officeName}</h1>
+        {#if $staffList === null}
+            No users belonging in {officeName}
+        {:else}
+            {#each $staffList as staff}
+                <!-- Filtering removed staff -->
+                {#if staff.permission !== 0}
+                    <PersonRowGlobal
+                        {...staff}
+                        iconSize={IconSize.Large} 
+                        on:overflowClick={overflowClickHandler} 
+                    />
+                {/if}
+            {/each}
+        {/if}
+    {/await}
+
+    {#if currentContext?.ty === RowType.Person}
+        <PersonContextGlobal
+            bind:show={showContextMenu}
+            payload={currentContext} 
+            on:editGlobalPermission={contextMenuHandler}
+            on:removeStaff={contextMenuHandler}
+        />
+    {/if}
+
+    <Modal title="Edit Global Permissions" bind:showModal={showGlobalPermission}>
+        {#if currentContext === null}
+            Current user is not a staff of the selected office.
+        {:else}
+            <GlobalPermissions payload={currentContext} />
+        {/if}
+    </Modal>
+{/if}

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-    import { dashboardState } from '../stores/DashboardState';
     import { userList } from '../stores/UserStore';
-    import { allOffices } from '../stores/OfficeStore';
 
     import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
     import PersonRowGlobal from '../../../components/ui/itemrow/PersonRowGlobal.svelte';
     import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import PersonContextGlobal from '../../../components/ui/contextdrawer/PersonContextGlobal.svelte';
-
-    $: ({ currentOffice } = $dashboardState);
-    $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
     let showContextMenu = false;
     let showGlobalPermission = false;
@@ -67,4 +62,3 @@
         <GlobalPermissions payload={currentContext} />
     {/if}
 </Modal>
-

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -52,7 +52,7 @@
 
 <Modal title="Edit Global Permissions" bind:showModal={showGlobalPermission}>
     {#if currentContext === null}
-        Current user is non existent
+        Current user is non-existent.
     {:else}
         <GlobalPermissions payload={currentContext} />
     {/if}

--- a/client/src/pages/dashboard/views/index.ts
+++ b/client/src/pages/dashboard/views/index.ts
@@ -1,7 +1,7 @@
 import Barcodes from './Barcodes.svelte';
 import Drafts from './Drafts.svelte';
 import Inbox from './Inbox.svelte';
-import ManageAdministrators from './Admins.svelte';
+import ManageUsers from './Users.svelte';
 import ManageGlobalSettings from './Settings.svelte';
 import ManageInvites from './Invites.svelte';
 import ManageStaff from './Staff.svelte';
@@ -13,7 +13,7 @@ export default {
     '/barcodes': Barcodes,
     '/drafts': Drafts,
     '/inbox': Inbox,
-    '/admin': ManageAdministrators,
+    '/users': ManageUsers,
     '/settings': ManageGlobalSettings,
     '/invites': ManageInvites,
     '/staff': ManageStaff,


### PR DESCRIPTION
This pull request aims to:

- Rename `Admin` to `Users` subpage
- Add `userList `store
- Remove `EditGlobalPermission `from Sandbox
- Change the argument of `EditGlobalPermission` from separate User to a `PersonPayload`
- Display Users and handle `EditGlobalPermission `in User subpage

Note: `pnpm lint` results to `HeapError `in local machine. Will do linting based on the checks here.
Note:  Still follows the old convention (event-based) instead of @BastiDood suggestion of using state-transition based. Will refractor after PR #79 is merged.