### PR TITLE
feat(server): implement dossier getter

### DIFF
--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -4,14 +4,16 @@ import type { Document as DocumentType } from '~model/document.ts';
 import type { Office } from '~model/office.ts';
 
 import {
-    type BarcodeAssignmentError,
     type AllInbox,
     type AllOutbox,
+    type BarcodeAssignmentError,
+    type InboxEntry,
     type PaperTrail,
-    BarcodeAssignmentErrorSchema,
-    PaperTrailSchema,
     AllInboxSchema,
     AllOutboxSchema,
+    BarcodeAssignmentErrorSchema,
+    InboxEntrySchema,
+    PaperTrailSchema,
 } from '../../../model/src/api.ts';
 import { type Snapshot, SnapshotSchema } from '../../../model/src/snapshot.ts';
 
@@ -41,6 +43,21 @@ export namespace Document {
         switch (res.status) {
             case StatusCodes.CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
             case StatusCodes.CONFLICT: return BarcodeAssignmentErrorSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
+    export async function getDossier(oid: Office['id']): Promise<InboxEntry[]> {
+        const res = await fetch(`/api/dossier?office=${oid}`, {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return InboxEntrySchema.array().parse(await res.json());
             case StatusCodes.BAD_REQUEST: throw new InvalidInput;
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -2,6 +2,7 @@ import {
     assert,
     assertArrayIncludes,
     assertEquals,
+    assertExists,
     assertFalse,
     assertInstanceOf,
     assertNotStrictEquals,
@@ -62,11 +63,11 @@ Deno.test('full OAuth flow', async t => {
             email,
             permission,
         });
-        assert(creation !== null);
+        assertExists(creation);
         assertEquals(await db.getInvitationList(office), [ { creation, office, email, permission } ]);
 
         const result = await db.revokeInvitation(office, email);
-        assert(result !== null);
+        assertExists(result);
         assertEquals(result, { permission, creation });
         assertEquals(await db.getInvitationList(office), [ ]);
     });
@@ -98,7 +99,7 @@ Deno.test('full OAuth flow', async t => {
             permission: USER.permission,
         };
         const creation = await db.upsertInvitation(invite);
-        assert(creation !== null);
+        assertExists(creation);
         assertEquals(await db.getInvitationList(office), [ { creation, office, email: USER.email, permission: USER.permission } ]);
 
         await t.step('invalid revocation of invites', async () => {
@@ -137,10 +138,10 @@ Deno.test('full OAuth flow', async t => {
 
         await t.step('invite acceptance', async () => {
             const creation = await db.upsertInvitation(invite);
-            assert(creation !== null);
+            assertExists(creation);
 
             const result = await db.insertInvitedUser(USER);
-            assert(result !== null);
+            assertExists(result)
             assertArrayIncludes(result, [ { office: invite.office, permission: invite.permission } ]);
             assertEquals(await db.getInvitationList(office), [ ]);
             assertStrictEquals(await db.upsertInvitation({
@@ -168,7 +169,7 @@ Deno.test('full OAuth flow', async t => {
         assertStrictEquals(await db.getStaffFromSession(id, office), null);
 
         const result = await db.invalidateSession(id);
-        assert(result !== null);
+        assertExists(result);
         assertEquals(result.data, { nonce, expiration });
     });
 
@@ -216,7 +217,7 @@ Deno.test('full OAuth flow', async t => {
 
         // Existing session
         const info = await db.getFullSessionInfo(id);
-        assert(info !== null);
+        assertExists(info);
         assertEquals(info.id, USER.id);
         assertEquals(info.name, USER.name);
         assertEquals(info.email, USER.email);
@@ -231,7 +232,7 @@ Deno.test('full OAuth flow', async t => {
 
         const first = 'Leave of Absence';
         const id = await db.createCategory(first);
-        assert(id !== null);
+        assertExists(id);
         assertEquals(await db.activateCategory(id), first);
 
         const { active: oldCategories } = await db.getAllCategories();
@@ -276,8 +277,7 @@ Deno.test('full OAuth flow', async t => {
 
     await t.step('valid session invalidation', async () => {
         const result = await db.invalidateSession(id);
-        assert(result !== null);
-        assertEquals(result.data, {
+        assertEquals(result?.data, {
             user_id: USER.id,
             expiration,
         });
@@ -288,7 +288,7 @@ Deno.test('full OAuth flow', async t => {
     assertStrictEquals(randomCategory.length, 19);
 
     const category = await db.createCategory(randomCategory);
-    assert(category !== null);
+    assertExists(category);
 
     const [ chosen, ...others ] = codes;
     assert(chosen);
@@ -324,7 +324,7 @@ Deno.test('full OAuth flow', async t => {
         assertEquals(await db.getDossier(office), expected);
 
         const info = await db.getEarliestAvailableBatch(office);
-        assert(info !== null);
+        assertExists(info);
         assertEquals(info.creation, batchCreation);
         assertStrictEquals(info.batch, batch);
         assertStrictEquals(info.codes.length, 9);

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -8,20 +8,22 @@ import type { PushSubscription, PushSubscriptionJson } from '~model/subscription
 
 import {
     type AllCategories,
+    type AllInbox,
     type AllOffices,
+    type AllOutbox,
     type FullSession,
     type GeneratedBatch,
-    type AllInbox,
-    type AllOutbox,
+    type InboxEntry,
     type MinBatch,
     type PaperTrail,
     type StaffMember,
     AllCategoriesSchema,
+    AllInboxSchema,
     AllOfficesSchema,
+    AllOutboxSchema,
     BarcodeAssignmentError,
     FullSessionSchema,
-    AllInboxSchema,
-    AllOutboxSchema,
+    InboxEntrySchema,
     InsertSnapshotError,
     MinBatchSchema,
     PaperTrailSchema,
@@ -388,6 +390,19 @@ export class Database {
                     INNER JOIN category AS c ON d.category = c.id
                 WHERE s.doc = ${doc} ORDER BY s.creation ASC`;
         return PaperTrailSchema.array().parse(rows);
+    }
+
+    /** Gets a list of {@linkcode InboxEntry} such that they were registered from the given office.  */
+    async getDossier(oid: Office['id']): Promise<InboxEntry[]> {
+        const { rows } = await this.#client
+            .queryObject`SELECT s.doc,d.title,c.name AS category,s.creation FROM snapshot AS s
+                INNER JOIN document AS d ON s.doc = d.id
+                INNER JOIN category AS c ON d.category = c.id
+                INNER JOIN barcode AS bar ON s.doc = bar.code
+                INNER JOIN batch AS bat ON bar.batch = bat.id
+            WHERE s.status = 'Register' AND bat.office = ${oid}
+            ORDER BY s.creation DESC`;
+        return InboxEntrySchema.array().parse(rows);
     }
 
     async getInbox(oid: Office['id']): Promise<AllInbox> {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -563,7 +563,6 @@ export class Database {
     }
 
     async getUsers(): Promise<User[]> {
-        // TODO: Add Tests
         const { rows } = await this.#client
             .queryObject('SELECT id,name,email,picture,permission FROM users');
         return UserSchema

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -88,7 +88,7 @@ export async function handleCreateDocument(pool: Pool, req: Request, params: URL
 
         if (barcodeResult instanceof Date) {
             info(`[Document] User ${staff.user_id} assigned barcode ${doc.id} to document "${doc.title}"`);
-            return new Response(barcodeResult.getUTCMilliseconds().toString(), {
+            return new Response(barcodeResult.getTime().toString(), {
                 status: Status.Created,
                 headers: { 'Content-Type': 'application/json' },
             });

--- a/server/src/routes/api/snapshot.ts
+++ b/server/src/routes/api/snapshot.ts
@@ -81,7 +81,7 @@ export async function handleInsertSnapshot(pool: Pool, req: Request, params: URL
         const snap: Snapshot['creation'] | InsertSnapshotError = await db.insertSnapshot({ ...result.data, evaluator: staff.user_id });
         if (snap instanceof Date) {
             info(`[Snapshot] User ${staff.user_id} inserted ${result.data.status} snapshot for document ${result.data.doc} to ${result.data.target}`);
-            return new Response(snap.getUTCMilliseconds().toString(), {
+            return new Response(snap.getTime().toString(), {
                 status: Status.Created,
                 headers: { 'Content-Type': 'application/json' },
             });

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -14,7 +14,7 @@ import {
     handleDeleteCategory,
     handleActivateCategory,
 } from './api/category.ts';
-import { handleCreateDocument, handleGetInbox, handleGetPaperTrail, handleGetOutbox } from './api/document.ts';
+import { handleCreateDocument, handleGetDossier, handleGetInbox, handleGetPaperTrail, handleGetOutbox } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation, handleGetInvitedList } from './api/invite.ts';
 import { handleGenerateGlobalSummary, handleGenerateLocalSummary, handleGenerateUserSummary } from './api/metrics.ts';
 import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
@@ -34,6 +34,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/batch': return handleGetEarliestAvailableBatch(pool, req, searchParams);
         case '/api/categories': return handleGetAllCategories(pool, req);
         case '/api/document': return handleGetPaperTrail(pool, req, searchParams);
+        case '/api/dossier': return handleGetDossier(pool, req, searchParams);
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
         case '/api/invites': return handleGetInvitedList(pool, req, searchParams);
         case '/api/outbox': return handleGetOutbox(pool, req, searchParams);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2,6 +2,7 @@ import {
     assert,
     assertArrayIncludes,
     assertEquals,
+    assertExists,
     assertInstanceOf,
     assertNotStrictEquals,
     assertStrictEquals,
@@ -49,7 +50,7 @@ async function setup(pool: Pool) {
             permission,
             email,
         });
-        assertNotStrictEquals(creation, null);
+        assertExists(creation);
 
         // Construct mock user
         const user = {
@@ -61,7 +62,7 @@ async function setup(pool: Pool) {
 
         // Formally integrate user into the system
         const offices = await db.insertInvitedUser(user);
-        assert(offices !== null);
+        assertExists(offices);
         const [ first, ...rest ] = offices;
         assertStrictEquals(rest.length, 0);
         assertEquals(first, { office: oid, permission });
@@ -76,7 +77,7 @@ async function setup(pool: Pool) {
             user_id: user.id,
             expiration,
         });
-        assert(pending !== null);
+        assertExists(pending);
         assertEquals(pending.expiration, expiration);
         assert(bytewiseEquals(pending.nonce, nonce));
         return { oid, sid: id, user };
@@ -155,7 +156,7 @@ Deno.test('full API integration test', async t => {
             office: oid,
             permission: Local.AddStaff,
         });
-        assert(creation !== null);
+        assertExists(creation);
 
         // List one invitation
         assertEquals(await Invite.getList(oid), [ { office: oid, creation, email, permission: Local.AddStaff } ]);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -236,6 +236,9 @@ Deno.test('full API integration test', async t => {
         assertStrictEquals(initial.batch, bid);
         assertEquals(initial.codes, codes);
 
+        // Dossier should be initially empty
+        assertEquals(await Document.getDossier(oid), [ ]);
+
         for (const code of codes) {
             const batch = await Batch.getEarliestBatch(oid);
             assertInstanceOf(batch?.creation, Date);
@@ -259,8 +262,14 @@ Deno.test('full API integration test', async t => {
             const [ extracted, ...rest ]: string[] = initial.codes.splice(index, 1);
             assertStrictEquals(rest.length, 0);
             assertStrictEquals(extracted, code);
+
+            // Most recent entry in dossier should be this document
+            const expected = { doc: code, title: 'Leave of Absence', creation: doc, category: cName };
+            const dossier = await Document.getDossier(oid);
+            assertEquals(dossier[0], expected);
         }
 
+        // There should be no more available codes
         assertStrictEquals(await Batch.getEarliestBatch(oid), null);
     });
 


### PR DESCRIPTION
As needed by @SporadicToast's sprint goals, this PR implements the API endpoint `GET /api/dossier?office={oid}`, which retrieves the "dossier" of a given office. The dossier is essentially a list of documents (a.k.a., `InboxEntry[]`) that the office has registered themselves (regardless of the current snapshot of the document).

Normally, these documents would disappear from the office inbox once received by the target office. Now, this endpoint enables the source office to nevertheless view all their sent documents so that they may view its paper trail.