### PR TITLE
feat(server): implement barcode metrics

### DIFF
--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
+import { type BarcodeMetrics, BarcodeMetricsSchema } from '../../../model/src/api.ts';
 import { type Metrics as MetricsType, MetricsSchema } from '../../../model/src/metrics.ts';
 import type { Office } from '../../../model/src/office.ts';
 
@@ -12,6 +13,20 @@ import {
 } from './error.ts';
 
 export namespace Metrics {
+    export async function generateBarcodeSummary(oid: Office['id']): Promise<BarcodeMetrics> {
+        const res = await fetch(`/api/metrics/barcode?office=${oid}`, {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return BarcodeMetricsSchema.parse(await res.json());
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
     export async function generateUserSummary(): Promise<MetricsType> {
         const res = await fetch('/api/metrics/user', {
             credentials: 'same-origin',

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -20,6 +20,7 @@ export namespace Metrics {
         });
         switch (res.status) {
             case StatusCodes.OK: return BarcodeMetricsSchema.parse(await res.json());
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -112,3 +112,9 @@ export type DeferredSnapshot = z.infer<typeof DeferredSnapshotSchema>
 
 export const DeferredRegistrationSchema = DocumentSchema.pick({ id: true });
 export type DeferredRegistration = z.infer<typeof DeferredRegistrationSchema>
+
+export const BarcodeMetricsSchema = z.object({
+    assigned: z.number().int().nonnegative(),
+    pending: z.number().int().nonnegative(),
+});
+export type BarcodeMetrics = z.infer<typeof BarcodeMetricsSchema>;

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -425,10 +425,15 @@ Deno.test('full OAuth flow', async t => {
             assert(global.Send ?? 0 > 0);
             assertStrictEquals(global.Receive, undefined);
             assertStrictEquals(global.Terminate, undefined);
+
+            const { assigned, pending } = await db.generateBarcodeSummary(office);
+            assertStrictEquals(assigned, 1);
+            assertStrictEquals(pending, 9);
         });
     });
 
     await t.step('fully populate the batch - cleanup', async () => {
+
         // Assign barcodes to documents
         for (const other of others) {
             const result = await db.assignBarcodeToDocument(
@@ -445,6 +450,7 @@ Deno.test('full OAuth flow', async t => {
             );
             assertInstanceOf(result, Date);
         }
+
 
         // There should be no remaining codes left
         assertStrictEquals(await db.getEarliestAvailableBatch(office), null);

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -11,6 +11,7 @@ import {
     type AllInbox,
     type AllOffices,
     type AllOutbox,
+    type BarcodeMetrics,
     type FullSession,
     type GeneratedBatch,
     type InboxEntry,
@@ -22,6 +23,7 @@ import {
     AllOfficesSchema,
     AllOutboxSchema,
     BarcodeAssignmentError,
+    BarcodeMetricsSchema,
     FullSessionSchema,
     InboxEntrySchema,
     InsertSnapshotError,
@@ -654,6 +656,16 @@ export class Database {
             case 1: return true;
             default: unreachable();
         }
+    }
+
+    async generateBarcodeSummary(oid: Office['id']): Promise<BarcodeMetrics> {
+        // TODO: Add Tests
+        const { rows: [ first, ...rest ] } = await this.#client
+            .queryObject`WITH _ AS (SELECT code FROM barcode AS bar INNER JOIN batch AS bat ON bar.batch = bat.id WHERE bat.office = ${oid}),
+                codes AS (SELECT id FROM _ LEFT JOIN document AS d ON id = code)
+                SELECT json_build_object('assigned', (SELECT COUNT(id) FROM codes), 'pending', (SELECT SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) FROM codes)) AS result`;
+        assertStrictEquals(rest.length, 0);
+        return BarcodeMetricsSchema.parse(first);
     }
 
     /** Generate a user-centric summary of the metrics (across all offices). */

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -659,13 +659,12 @@ export class Database {
     }
 
     async generateBarcodeSummary(oid: Office['id']): Promise<BarcodeMetrics> {
-        // TODO: Add Tests
         const { rows: [ first, ...rest ] } = await this.#client
             .queryObject`WITH _ AS (SELECT code FROM barcode AS bar INNER JOIN batch AS bat ON bar.batch = bat.id WHERE bat.office = ${oid}),
                 codes AS (SELECT id FROM _ LEFT JOIN document AS d ON id = code)
                 SELECT json_build_object('assigned', (SELECT COUNT(id) FROM codes), 'pending', (SELECT SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) FROM codes)) AS result`;
         assertStrictEquals(rest.length, 0);
-        return BarcodeMetricsSchema.parse(first);
+        return z.object({ result: BarcodeMetricsSchema }).parse(first).result;
     }
 
     /** Generate a user-centric summary of the metrics (across all offices). */

--- a/server/src/routes/api/metrics.ts
+++ b/server/src/routes/api/metrics.ts
@@ -170,6 +170,7 @@ export async function handleGenerateGlobalSummary(pool: Pool, req: Request) {
  *
  * # Outputs
  * - `200` => returns the counts of the grouped snapshots as JSON in the {@linkcode Response} body
+ * - `400` => office ID is invalid or other unacceptable
  * - `401` => session ID is absent, expired, or otherwise malformed
  * - `403` => insufficient permissions
  * - `406` => content negotiation failed

--- a/server/src/routes/api/metrics.ts
+++ b/server/src/routes/api/metrics.ts
@@ -201,7 +201,7 @@ export async function handleGenerateBarcodeSummary(pool: Pool, req: Request, par
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        if ((staff.permission & Global.ViewMetrics) === 0) {
+        if ((staff.permission & Local.ViewMetrics) === 0) {
             error(`[Metrics] Staff ${staff.user_id} from office ${oid} cannot view barcode metrics summary`);
             return new Response(null, { status: Status.Forbidden });
         }

--- a/server/src/routes/api/metrics.ts
+++ b/server/src/routes/api/metrics.ts
@@ -161,3 +161,57 @@ export async function handleGenerateGlobalSummary(pool: Pool, req: Request) {
         db.release();
     }
 }
+
+/**
+ * Gets the summary of an office's barcode metrics.
+ *
+ * # Inputs
+ * - Requires a session whose global permissions include {@linkcode Local.ViewMetrics}
+ *
+ * # Outputs
+ * - `200` => returns the counts of the grouped snapshots as JSON in the {@linkcode Response} body
+ * - `401` => session ID is absent, expired, or otherwise malformed
+ * - `403` => insufficient permissions
+ * - `406` => content negotiation failed
+ */
+export async function handleGenerateBarcodeSummary(pool: Pool, req: Request, params: URLSearchParams) {
+    const { sid } = getCookies(req.headers);
+    if (!sid) {
+        error('[Metrics] Absent session ID');
+        return new Response(null, { status: Status.Unauthorized });
+    }
+
+    const office = params.get('office');
+    const oid = office ? parseInt(office, 10) : NaN;
+    if (isNaN(oid)) {
+        error(`[Metrics] Session ${sid} provided invalid office ID`);
+        return new Response(null, { status: Status.BadRequest });
+    }
+
+    if (accepts(req, 'application/json') === undefined) {
+        error(`[Metrics] Content negotiation failed for session ${sid}`);
+        return new Response(null, { status: Status.NotAcceptable });
+    }
+
+    const db = await Database.fromPool(pool);
+    try {
+        const staff = await db.getStaffFromSession(sid, oid);
+        if (staff === null) {
+            error(`[Metrics] Invalid session ${sid}`);
+            return new Response(null, { status: Status.Unauthorized });
+        }
+
+        if ((staff.permission & Global.ViewMetrics) === 0) {
+            error(`[Metrics] Staff ${staff.user_id} from office ${oid} cannot view barcode metrics summary`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
+        const bars = await db.generateBarcodeSummary(oid);
+        info(`[Metrics] Staff ${staff.user_id} from office ${oid} cannot view barcode metrics summary`);
+        return new Response(JSON.stringify(bars), {
+            headers: { 'Content-Type': 'application/json' },
+        });
+    } finally {
+        db.release();
+    }
+}

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -16,7 +16,12 @@ import {
 } from './api/category.ts';
 import { handleCreateDocument, handleGetDossier, handleGetInbox, handleGetPaperTrail, handleGetOutbox } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation, handleGetInvitedList } from './api/invite.ts';
-import { handleGenerateGlobalSummary, handleGenerateLocalSummary, handleGenerateUserSummary } from './api/metrics.ts';
+import {
+    handleGenerateGlobalSummary,
+    handleGenerateLocalSummary,
+    handleGenerateUserSummary,
+    handleGenerateBarcodeSummary,
+} from './api/metrics.ts';
 import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
@@ -38,6 +43,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
         case '/api/invites': return handleGetInvitedList(pool, req, searchParams);
         case '/api/outbox': return handleGetOutbox(pool, req, searchParams);
+        case '/api/metrics/barcode': return handleGenerateBarcodeSummary(pool, req, searchParams);
         case '/api/metrics/office': return handleGenerateLocalSummary(pool, req, searchParams);
         case '/api/metrics/system': return handleGenerateGlobalSummary(pool, req);
         case '/api/metrics/user': return handleGenerateUserSummary(pool, req);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -282,7 +282,6 @@ Deno.test('full API integration test', async t => {
             remark: 'Sending!',
         });
         assertInstanceOf(result, Date);
-        assert(new Date >= result);
     });
 
     await t.step('Metrics API', async () => {
@@ -305,6 +304,10 @@ Deno.test('full API integration test', async t => {
         assert(global.Send ?? 0 > 0);
         assertStrictEquals(global.Receive, undefined);
         assertStrictEquals(global.Terminate, undefined);
+
+        const { assigned, pending } = await Metrics.generateBarcodeSummary(oid);
+        assertStrictEquals(assigned, 10);
+        assertStrictEquals(pending, 0);
     });
 
     await t.step('Category API - retirement', async () => {


### PR DESCRIPTION
As needed by @Arukuen, this PR implements basic metrics (via the `GET /api/metrics/barcode` endpoint) for office barcodes.