### PR TITLE
refactor(client): prefer state-machines to manage dialogs

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -57,24 +57,3 @@ export enum Events {
     RemoveCategory = 'removeCategory',
     RenameCategory = 'renameCategory',
 }
-
-export interface InvitePayload {
-    ty: RowType.Invite;
-    email: Invitation['email'];
-    office: Invitation['office'];
-}
-
-export interface PersonPayload {
-    ty: RowType.Person;
-    id: Staff['user_id'];
-    office: Staff['office'];
-    email: User['email'];
-    permission: Staff['permission'];
-}
-
-export interface GlobalPersonPayload {
-    ty: RowType.Person;
-    id: User['id'];
-    email: User['email'];
-    permission: Staff['permission'];
-}

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -1,8 +1,3 @@
-import { Document } from '../../../model/src/document.ts';
-import { Invitation } from '../../../model/src/invitation.ts';
-import { Staff } from '../../../model/src/staff.ts';
-import { User } from '../../../model/src/user.ts';
-
 export enum MetricsMode {
     User,
     Local,

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -58,11 +58,6 @@ export enum Events {
     RenameCategory = 'renameCategory',
 }
 
-export interface ContextPayload {
-    ty: RowType.AcceptDocument | RowType.Inbox;
-    id: Document['id'];
-}
-
 export interface InvitePayload {
     ty: RowType.Invite;
     email: Invitation['email'];

--- a/client/src/components/ui/contextdrawer/AcceptContext.svelte
+++ b/client/src/components/ui/contextdrawer/AcceptContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
 
-    import { Events, ContextPayload, IconSize } from '../../types.ts';
+    import { Events, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
     import ContextDivider from '../contextmenu/ContextDivider.svelte';
@@ -11,27 +11,26 @@
     import Camera from '../../icons/Camera.svelte';
 
     const dispatch = createEventDispatcher();
-    export let show = false;
-    export let payload: ContextPayload;
+    export let showMenu = false;
     export let iconSize = IconSize.Normal;
 </script>
 
-<ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.AcceptDocument, payload)}>
+<ContextTemplate on:close bind:show={showMenu}>
+    <ContextElement on:click={() => dispatch(Events.AcceptDocument)}>
         <div slot="contextIcon">
             <Checkmark size={iconSize} alt="Accept Document" />
             Accept Document
         </div>
     </ContextElement>
     <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.DeclineDocument, payload)}>
+    <ContextElement on:click={() => dispatch(Events.DeclineDocument)}>
         <div slot="contextIcon">
             <Close size={iconSize} alt="Decline Document" />
             Decline Document
         </div>
     </ContextElement>
     <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.Camera, payload)}>
+    <ContextElement on:click={() => dispatch(Events.Camera)}>
         <div slot="contextIcon">
             <Camera size={iconSize} alt="Select an Image" />
             Take a Picture / Choose a Image

--- a/client/src/components/ui/contextdrawer/InboxContext.svelte
+++ b/client/src/components/ui/contextdrawer/InboxContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
 
-    import { Events, ContextPayload, IconSize } from '../../types.ts';
+    import { Events, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
     import ContextDivider from '../contextmenu/ContextDivider.svelte';
@@ -10,20 +10,19 @@
     import CheckboxIndeterminateFilled from '../../icons/CheckboxIndeterminateFilled.svelte';
 
     const dispatch = createEventDispatcher();
-    export let show = false;
-    export let payload: ContextPayload;
+    export let showMenu = false;
     export let iconSize = IconSize.Normal;
 </script>
 
-<ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.SendDocument, payload)}>
+<ContextTemplate on:close bind:show={showMenu}>
+    <ContextElement on:click={() => dispatch(Events.SendDocument)}>
         <div slot="contextIcon">
             <SendAlt size={iconSize} alt="Send Document" />
             Send Document
         </div>
     </ContextElement>
     <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.TerminateDocument, payload)}>
+    <ContextElement on:click={() => dispatch(Events.TerminateDocument)}>
         <div slot="contextIcon">
             <CheckboxIndeterminateFilled size={iconSize} alt="Terminate Document" />
             Terminate Document

--- a/client/src/components/ui/contextdrawer/InviteContext.svelte
+++ b/client/src/components/ui/contextdrawer/InviteContext.svelte
@@ -9,15 +9,14 @@
 
     const dispatch = createEventDispatcher();
     export let show = false as boolean;
-    export let payload: InvitePayload;
     export let iconSize = IconSize.Normal;
 </script>
 
-<ContextTemplate bind:show>
-    <ContextElement on:click={() => dispatch(Events.RemoveInvitation, payload)}>
+<ContextTemplate on:close bind:show>
+    <ContextElement on:click={() => dispatch(Events.RemoveInvitation)}>
         <div slot="contextIcon">
             <Close size={iconSize} alt="Cancel Invitation" />
-            Revoke invite of <b>{payload.email}</b>
+            Cancel Invitation
         </div>
     </ContextElement>
 </ContextTemplate>

--- a/client/src/components/ui/contextdrawer/InviteContext.svelte
+++ b/client/src/components/ui/contextdrawer/InviteContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
 
-    import { Events, InvitePayload, IconSize } from '../../types.ts';
+    import { Events, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
 

--- a/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
@@ -9,12 +9,11 @@
 
     const dispatch = createEventDispatcher();
     export let show = false as boolean;
-    export let payload: PersonPayload;
     export let iconSize = IconSize.Normal;
 </script>
 
-<ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.EditGlobalPermission, payload)}>
+<ContextTemplate on:close bind:show={show}>
+    <ContextElement on:click={() => dispatch(Events.EditGlobalPermission)}>
         <div slot="contextIcon">
             <Edit size={iconSize} alt="Edit Local Permissions" />
             Edit Global Permissions

--- a/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextGlobal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
 
-    import { Events, PersonPayload, IconSize } from '../../types.ts';
+    import { Events, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
 

--- a/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
@@ -11,19 +11,18 @@
 
     const dispatch = createEventDispatcher();
     export let show = false;
-    export let payload: PersonPayload;
     export let iconSize = IconSize.Normal;
 </script>
 
-<ContextTemplate bind:show={show}>
-    <ContextElement on:click={() => dispatch(Events.EditLocalPermission, payload)}>
+<ContextTemplate on:close bind:show={show}>
+    <ContextElement on:click={() => dispatch(Events.EditLocalPermission)}>
         <div slot="contextIcon">
             <Edit size={iconSize} alt="Edit Local Permissions" />
             Edit Local Permissions
         </div>
     </ContextElement>
     <ContextDivider />
-    <ContextElement on:click={() => dispatch(Events.RemoveStaff, payload)}>
+    <ContextElement on:click={() => dispatch(Events.RemoveStaff)}>
         <div slot="contextIcon">
             <PersonDelete size={iconSize} alt="Remove Staff" />
             Remove Staff

--- a/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
+++ b/client/src/components/ui/contextdrawer/PersonContextLocal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
 
-    import { Events, PersonPayload, IconSize } from '../../types.ts';
+    import { Events, IconSize } from '../../types.ts';
     import ContextTemplate from '../contextmenu/ContextTemplate.svelte';
     import ContextElement from '../contextmenu/ContextElement.svelte';
     import ContextDivider from '../contextmenu/ContextDivider.svelte';

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -51,12 +51,12 @@
             await documentInbox.reload?.();
             await documentOutbox.reload?.();
             await reloadMetrics();
-            dispatch(Events.Done)
+            dispatch(Events.Done);
         } catch (err) {
             if (err instanceof DeferredSnap) {
                 await deferredSnaps.upsert({ status: Status.Register, doc: docId });
                 topToastMessage.enqueue({ title: err.name, body: `${docId} is deferred.` });
-                dispatch(Events.Done)
+                dispatch(Events.Done);
                 return;
             }
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/office/AddInvite.svelte
+++ b/client/src/components/ui/forms/office/AddInvite.svelte
@@ -15,7 +15,7 @@
 
     let email = '';
 
-    const dispatch = createEventDispatcher()
+    const dispatch = createEventDispatcher();
     async function handleSubmit(this: HTMLFormElement) {
         // Computes permissions
         let permission = 0;
@@ -37,7 +37,7 @@
             await Invite.add({ email, office, permission });
             await inviteList.reload?.();
             this.reset();
-            dispatch(Events.Done)
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/office/AddInvite.svelte
+++ b/client/src/components/ui/forms/office/AddInvite.svelte
@@ -1,7 +1,9 @@
 <script lang='ts'>
+    import { createEventDispatcher } from 'svelte';
     import { assert } from '../../../../assert.ts';
     import { Invite } from '../../../../api/invite.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
+    import { Events } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import Checkmark from '../../../icons/Checkmark.svelte';
@@ -13,6 +15,7 @@
 
     let email = '';
 
+    const dispatch = createEventDispatcher()
     async function handleSubmit(this: HTMLFormElement) {
         // Computes permissions
         let permission = 0;
@@ -34,6 +37,7 @@
             await Invite.add({ email, office, permission });
             await inviteList.reload?.();
             this.reset();
+            dispatch(Events.Done)
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/office/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/office/RevokeInvite.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+    import { createEventDispatcher } from 'svelte';
     import { Invitation } from '~model/invitation';
     import { Office } from '~model/office';
 
     import { assert } from '../../../../assert.ts';
 
     import { Invite } from '../../../../api/invite.ts';
-    import { ButtonType, IconColor } from '../../../types.ts';
+    import { ButtonType, IconColor, Events } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
@@ -28,12 +29,14 @@
                 email,
             });
             await inviteList.reload?.();
+            dispatch(Events.Done)
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
         }
     }
 
+    const dispatch = createEventDispatcher()
 </script>
 
 <p> Are you sure you want to remove the invitation for {email} in {officeName}?</p>

--- a/client/src/components/ui/forms/office/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/office/RevokeInvite.svelte
@@ -18,6 +18,7 @@
     export let email: Invitation['email'];
     export let office: Office['id'];
 
+    const dispatch = createEventDispatcher();
     $: officeName = $allOffices[office] ?? 'No office name.';
 
     async function removeInviteHandler() {
@@ -29,14 +30,12 @@
                 email,
             });
             await inviteList.reload?.();
-            dispatch(Events.Done)
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
         }
     }
-
-    const dispatch = createEventDispatcher()
 </script>
 
 <p> Are you sure you want to remove the invitation for {email} in {officeName}?</p>

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
+    import { createEventDispatcher } from 'svelte';
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
 
-    import { User } from '../../../../api/user.ts';
-    import { PersonPayload, IconColor } from '../../../types.ts';
+    import { User as Api} from '../../../../api/user.ts';
+    import { IconColor, Events } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
+    import { User } from '~model/user.ts';
 
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 
     import { topToastMessage } from '../../../../pages/dashboard/stores/ToastStore.ts';
     import { userList } from '../../../../pages/dashboard/stores/UserStore.ts';
+    import { Staff } from '~model/staff.ts';
 
-    export let payload: PersonPayload;
+    export let id: Staff['user_id'];
+    export let permission: User['permission'];
+
+    const dispatch = createEventDispatcher()
 
     async function handleSubmit(this: HTMLFormElement) {
         // Recompute permissions before submitting
@@ -27,15 +33,19 @@
         });
 
         // No point in handling no-changes.
-        if (payload.permission === permsVal) return;
+        if (permission === permsVal) {
+            dispatch(Events.Done);
+            return;
+        }
 
         try {
             // Rebuild pseudo-user object
-            await User.setPermission({
-                id: payload.id,
+            await Api.setPermission({
+                id: id,
                 permission: permsVal,
             });
             await userList.reload?.();
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -44,13 +54,13 @@
 </script>
 
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
-    <p>User ID: {payload.id}</p>
+    <p>User ID: {id}</p>
     <label>
         <input
             type="checkbox"
             name="perms"
             value={Global.GetOffices}
-            checked={checkPerms(payload.permission, Global.GetOffices)}
+            checked={checkPerms(permission, Global.GetOffices)}
         />
         Get Offices
     </label>
@@ -59,7 +69,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateOffice}
-            checked={checkPerms(payload.permission, Global.CreateOffice)}
+            checked={checkPerms(permission, Global.CreateOffice)}
         />
         Create Office
     </label>
@@ -68,7 +78,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateOffice}
-            checked={checkPerms(payload.permission, Global.UpdateOffice)}
+            checked={checkPerms(permission, Global.UpdateOffice)}
         />
         Update Office
     </label>
@@ -77,7 +87,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateUser}
-            checked={checkPerms(payload.permission, Global.UpdateUser)}
+            checked={checkPerms(permission, Global.UpdateUser)}
         />
         Update User
     </label>
@@ -86,7 +96,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateCategory}
-            checked={checkPerms(payload.permission, Global.CreateCategory)}
+            checked={checkPerms(permission, Global.CreateCategory)}
         />
         Create Category
     </label>
@@ -95,7 +105,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateCategory}
-            checked={checkPerms(payload.permission, Global.UpdateCategory)}
+            checked={checkPerms(permission, Global.UpdateCategory)}
         />
         Update Category
     </label>
@@ -104,7 +114,7 @@
             type="checkbox"
             name="perms"
             value={Global.DeleteCategory}
-            checked={checkPerms(payload.permission, Global.DeleteCategory)}
+            checked={checkPerms(permission, Global.DeleteCategory)}
         />
         Delete Category
     </label>
@@ -113,7 +123,7 @@
             type="checkbox"
             name="perms"
             value={Global.ActivateCategory}
-            checked={checkPerms(payload.permission, Global.ActivateCategory)}
+            checked={checkPerms(permission, Global.ActivateCategory)}
         />
         Activate Category
     </label>
@@ -122,7 +132,7 @@
             type="checkbox"
             name="perms"
             value={Global.ViewMetrics}
-            checked={checkPerms(payload.permission, Global.ViewMetrics)}
+            checked={checkPerms(permission, Global.ViewMetrics)}
         />
         View Metrics
     </label>

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -3,7 +3,7 @@
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
 
-    import { User as Api} from '../../../../api/user.ts';
+    import { User as Api } from '../../../../api/user.ts';
     import { IconColor, Events } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
     import { User } from '~model/user.ts';
@@ -18,7 +18,7 @@
     export let id: Staff['user_id'];
     export let permission: User['permission'];
 
-    const dispatch = createEventDispatcher()
+    const dispatch = createEventDispatcher();
 
     async function handleSubmit(this: HTMLFormElement) {
         // Recompute permissions before submitting

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -2,7 +2,7 @@
     import { createEventDispatcher } from 'svelte';
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
-    import { Events, IconColor, PersonPayload } from '../../../types.ts';
+    import { Events, IconColor } from '../../../types.ts';
     import { Staff as Api } from '../../../../api/staff.ts';
     import { Staff } from '~model/staff.ts';
     import { User } from '~model/user.ts';
@@ -50,7 +50,7 @@
 
             // Reload the staffList store
             await staffList.reload?.();
-            dispatch(Events.Done)
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { createEventDispatcher } from 'svelte';
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
-    import { IconColor, PersonPayload } from '../../../types.ts';
-    import { Staff } from '../../../../api/staff.ts';
+    import { Events, IconColor, PersonPayload } from '../../../types.ts';
+    import { Staff as Api } from '../../../../api/staff.ts';
+    import { Staff } from '~model/staff.ts';
+    import { User } from '~model/user.ts';
     import { Local } from '../../../../../../model/src/permission.ts';
 
     import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
@@ -12,7 +15,12 @@
     import Button from '../../Button.svelte';
     import Edit from '../../../icons/Edit.svelte';
 
-    export let payload: PersonPayload;
+    export let officeId: Staff['office'];
+    export let permission: Staff['permission'];
+    export let userId: Staff['user_id'];
+    export let email: User['email'];
+
+    const dispatch = createEventDispatcher();
 
     async function handleSubmit(this: HTMLFormElement) {
         // Recompute permissions before submitting
@@ -27,18 +35,22 @@
         });
 
         // No point in handling no-changes.
-        if (payload.permission === permsVal) return;
+        if (permission === permsVal) {
+            dispatch(Events.Done);
+            return;
+        }
 
         try {
             // Rebuild pseudo-user object
-            await Staff.setPermission({
-                office: payload.office,
-                user_id: payload.id,
+            await Api.setPermission({
+                office: officeId,
+                user_id: userId,
                 permission: permsVal,
             });
 
             // Reload the staffList store
             await staffList.reload?.();
+            dispatch(Events.Done)
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -46,14 +58,14 @@
     }
 </script>
 
-<p>You are modifying {payload.email}'s permissions in {$allOffices[payload.office]}.</p>
+<p>You are modifying {email}'s permissions in {$allOffices[officeId]}.</p>
 <form on:submit|preventDefault|stopPropagation={handleSubmit}>
     <label>
         <input
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={checkPerms(payload.permission, Local.AddStaff)}
+            checked={checkPerms(permission, Local.AddStaff)}
         />
         Add Staff
     </label>
@@ -62,7 +74,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={checkPerms(payload.permission, Local.RemoveStaff)}
+            checked={checkPerms(permission, Local.RemoveStaff)}
         />
         Remove Staff
     </label>
@@ -71,7 +83,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={checkPerms(payload.permission, Local.UpdateStaff)}
+            checked={checkPerms(permission, Local.UpdateStaff)}
         />
         Update Staff
     </label>
@@ -80,7 +92,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={checkPerms(payload.permission, Local.AddInvite)}
+            checked={checkPerms(permission, Local.AddInvite)}
         />
         Add Invite
     </label>
@@ -89,7 +101,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={checkPerms(payload.permission, Local.RevokeInvite)}
+            checked={checkPerms(permission, Local.RevokeInvite)}
         />
         Revoke Invite
     </label>
@@ -98,7 +110,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={checkPerms(payload.permission, Local.ViewBatch)}
+            checked={checkPerms(permission, Local.ViewBatch)}
         />
         View Batch
     </label>
@@ -107,7 +119,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={checkPerms(payload.permission, Local.GenerateBatch)}
+            checked={checkPerms(permission, Local.GenerateBatch)}
         />
         Generate Batch
     </label>
@@ -116,7 +128,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={checkPerms(payload.permission, Local.InvalidateBatch)}
+            checked={checkPerms(permission, Local.InvalidateBatch)}
         />
         Invalidate Batch
     </label>
@@ -125,7 +137,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={checkPerms(payload.permission, Local.CreateDocument)}
+            checked={checkPerms(permission, Local.CreateDocument)}
         />
         Create Document
     </label>
@@ -134,7 +146,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={checkPerms(payload.permission, Local.InsertSnapshot)}
+            checked={checkPerms(permission, Local.InsertSnapshot)}
         />
         Insert Snapshot
     </label>
@@ -143,7 +155,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={checkPerms(payload.permission, Local.ViewMetrics)}
+            checked={checkPerms(permission, Local.ViewMetrics)}
         />
         View Metrics
     </label>
@@ -152,7 +164,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={checkPerms(payload.permission, Local.ViewInbox)}
+            checked={checkPerms(permission, Local.ViewInbox)}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -1,24 +1,32 @@
 <script lang="ts">
+    import { createEventDispatcher } from 'svelte';
     import { assert } from '../../../../assert.ts';
-    import { Staff } from '../../../../api/staff.ts';
-
+    import { Staff as Api } from '../../../../api/staff.ts';
+    import { Staff } from '~model/staff.ts';
+    import { User } from '~model/user.ts';
+    
     import { staffList } from '../../../../pages/dashboard/stores/StaffStore.ts';
     import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
     import { topToastMessage } from '../../../../pages/dashboard/stores/ToastStore.ts';
     
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
-    import { ButtonType, IconColor, PersonPayload } from '../../../types.ts';
+    import { ButtonType, Events, IconColor } from '../../../types.ts';
+    
 
-    export let payload: PersonPayload;
+    export let id: Staff['user_id'];
+    export let office: Staff['office'];
+    export let email: User['email'];
 
+    const dispatch = createEventDispatcher();
     async function handleRemove() {
         try {
-            await Staff.remove({
-                office: payload.office,
-                user_id: payload.id,
+            await Api.remove({
+                office: office,
+                user_id: id,
             });
             await staffList.reload?.();
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -27,7 +35,7 @@
 </script>
 
 
-<p>Are you sure you want to remove {payload.email} from {$allOffices[payload.office]}?</p>
+<p>Are you sure you want to remove {email} from {$allOffices[office]}?</p>
 <Button type={ButtonType.Danger} on:click={handleRemove}>
     <PersonDelete color={IconColor.White} alt="Remove Staff" on:click/>Remove Staff
 </Button>

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -20,16 +20,12 @@
     $: isDeferred = findDeferredSnapshot($deferredSnaps, doc);
 
     const dispatch = createEventDispatcher();
-    const rowEvent: ContextPayload = {
-        ty: RowType.AcceptDocument,
-        id: doc,
-    };
 </script>
 
 <RowTemplate
     {iconSize}
     {isDeferred}
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
     on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     {#if isDeferred} 

--- a/client/src/components/ui/itemrow/AcceptRow.svelte
+++ b/client/src/components/ui/itemrow/AcceptRow.svelte
@@ -4,7 +4,7 @@
     import DocumentImport from '../../icons/DocumentImport.svelte';
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { ContextPayload, RowType, IconSize, Events } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -3,7 +3,7 @@
     import DocumentBlank from '../../icons/DocumentBlank.svelte';
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { IconSize, ContextPayload, RowType, Events } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';
     import { Snapshot } from '~model/snapshot.ts';

--- a/client/src/components/ui/itemrow/InboxRow.svelte
+++ b/client/src/components/ui/itemrow/InboxRow.svelte
@@ -17,18 +17,13 @@
     export let creation: Snapshot['creation'];
 
     const dispatch = createEventDispatcher();
-    const rowEvent: ContextPayload = {
-        ty: RowType.Inbox,
-        id: doc,
-    };
-
     $: isDeferred = findDeferredSnapshot($deferredSnaps, doc);
 </script>
 
 <RowTemplate
     {iconSize} 
     {isDeferred}
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
     on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     {#if isDeferred} 

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -4,7 +4,7 @@
     import PersonMail from '../../icons/PersonMail.svelte';
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { IconSize, InvitePayload, RowType, Events } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { Invitation } from '../../../../../model/src/invitation.ts';
     import { Office } from '~model/office.ts';
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';

--- a/client/src/components/ui/itemrow/InviteRow.svelte
+++ b/client/src/components/ui/itemrow/InviteRow.svelte
@@ -18,17 +18,11 @@
     let targetName: Office['name'];
     
     const dispatch = createEventDispatcher();
-    const rowEvent: InvitePayload = {
-        ty: RowType.Invite,
-        email,
-        office,
-    };
-
     $: targetName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
 >
     <span class="title">{email}</span>
     <span slot="secondary" class="chipcontainer">

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -15,17 +15,11 @@
     export let permission: User['permission'];
 
     const dispatch = createEventDispatcher();
-    const rowEvent: GlobalPersonPayload = {
-        ty: RowType.Person,
-        id,
-        email,
-        permission,
-    };
 </script>
 
 <RowTemplate 
     {iconSize} 
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
 >
     <span class="chip office">User</span>
     <span class="title">{name}</span>    

--- a/client/src/components/ui/itemrow/PersonRowGlobal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowGlobal.svelte
@@ -3,7 +3,7 @@
 
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { GlobalPersonPayload, IconSize, Events, RowType } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { User } from '../../../../../model/src/user.ts';
     export let iconSize: IconSize;
     

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -4,7 +4,7 @@
 
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { PersonPayload, IconSize, Events, RowType } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
     import { User } from '../../../../../model/src/user.ts';
     import { Staff } from '../../../../../model/src/staff.ts';

--- a/client/src/components/ui/itemrow/PersonRowLocal.svelte
+++ b/client/src/components/ui/itemrow/PersonRowLocal.svelte
@@ -22,20 +22,13 @@
     export let permission: Staff['permission'];
 
     const dispatch = createEventDispatcher();
-    const rowEvent: PersonPayload = {
-        ty: RowType.Person,
-        id,
-        office,
-        email,
-        permission,
-    };
     
     $: officeName = $allOffices[office] ?? 'No office.';
 </script>
 
 <RowTemplate 
     {iconSize} 
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
 >
     <span class="chip office">{officeName}</span>
     <span class="title">{name}</span>    

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -20,11 +20,6 @@
     export let showOverflowIcon = true;
     
     const dispatch = createEventDispatcher();
-    const rowEvent: ContextPayload = {
-        ty: RowType.Inbox,
-        id: doc,
-    };
-
     $: isDeferred = findDeferredSnapshot($deferredSnaps, doc);
 </script>
 
@@ -32,7 +27,7 @@
     {iconSize} 
     {showOverflowIcon}
     {isDeferred}
-    on:overflowClick={() => dispatch(Events.OverflowClick, rowEvent)}
+    on:overflowClick={() => dispatch(Events.OverflowClick)}
     on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>

--- a/client/src/components/ui/itemrow/RegisterRow.svelte
+++ b/client/src/components/ui/itemrow/RegisterRow.svelte
@@ -5,7 +5,7 @@
     import DocumentBlank from '../../icons/DocumentBlank.svelte';
     import RowTemplate from '../RowTemplate.svelte';
 
-    import { IconSize, RowType, ContextPayload, Events } from '../../types.ts';
+    import { IconSize, Events } from '../../types.ts';
     import { deferredSnaps } from '../../../pages/dashboard/stores/DeferredStore.ts';
     import { Document } from '../../../../../model/src/document.ts';
     import { Category } from '~model/category.ts';

--- a/client/src/pages/dashboard/views/Barcodes.svelte
+++ b/client/src/pages/dashboard/views/Barcodes.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { assert } from '../../../assert.ts';
     import { Batch } from '../../../api/batch.ts';
-    import { BarcodeMetrics } from '~model/api.ts';
 
     import { earliestBatch } from '../stores/BatchStore.ts';
     import { dashboardState } from '../stores/DashboardState.ts';

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -61,7 +61,7 @@
         <p>Loading inbox...</p>
     {:then}
         <h2>Pending Acceptance</h2>
-        {#each $documentInbox.pending as {creation, category, title, doc} (doc)}
+        {#each $documentInbox.pending as { creation, category, title, doc } (doc)}
             <AcceptRow
                 {doc}
                 {category}
@@ -73,7 +73,7 @@
         {/each}
 
         <h2>Office Inbox</h2>
-        {#each $documentInbox.accept as {creation, category, title, doc} (doc)}
+        {#each $documentInbox.accept as { creation, category, title, doc } (doc)}
             <InboxRow
                 {doc}
                 {category}

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -61,20 +61,26 @@
         <p>Loading inbox...</p>
     {:then}
         <h2>Pending Acceptance</h2>
-        {#each $documentInbox.pending as entry (entry.doc)}
+        {#each $documentInbox.pending as {creation, category, title, doc} (doc)}
             <AcceptRow
-                {...entry}
+                {doc}
+                {category}
+                {title}
+                {creation}
                 iconSize = {IconSize.Large}
-                on:overflowClick = {setOpenedContext.bind(null, entry.doc, ActiveMenu.ContextAccept)}
+                on:overflowClick = {setOpenedContext.bind(null, doc, ActiveMenu.ContextAccept)}
             />
         {/each}
 
         <h2>Office Inbox</h2>
-        {#each $documentInbox.accept as entry (entry.doc)}
+        {#each $documentInbox.accept as {creation, category, title, doc} (doc)}
             <InboxRow
-                {...entry}
+                {doc}
+                {category}
+                {title}
+                {creation}
                 iconSize={IconSize.Large}
-                on:overflowClick={setOpenedContext.bind(null, entry.doc, ActiveMenu.ContextInbox)}
+                on:overflowClick={setOpenedContext.bind(null, doc, ActiveMenu.ContextInbox)}
             />
         {/each}
     {/await}

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -90,7 +90,7 @@
     <!-- Do not render anything! -->
 {:else if ctx.mode === Status.Register}
 <Modal title="Create Document" showModal on:close={resetContext}>
-    <CreateDocument on:done={resetContext}/>
+    <CreateDocument on:done={resetContext} />
 </Modal>
 {:else if ctx.context === ActiveMenu.ContextInbox && ctx.docId !== null}
     <InboxContext 

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -18,7 +18,7 @@
 
     enum ActiveMenu {
         ContextInbox,
-        ContextAccept, 
+        ContextAccept,
     }
 
     interface Context {
@@ -32,15 +32,15 @@
     $: ({ currentOffice } = $dashboardState);
     
     function openInsertSnapshot(doc: Document['id'], mode: Status) {
-        ctx = {docId: doc, mode: mode, context: null};
-    };
+        ctx = { docId: doc, mode: mode, context: null };
+    }
 
     function openCreateDocument() {
-        ctx = {docId: null, mode: Status.Register, context: null};
+        ctx = { docId: null, mode: Status.Register, context: null };
     }
 
     function setOpenedContext(doc: Document['id'], context: ActiveMenu) {
-        ctx = {docId: doc, mode: null, context: context};
+        ctx = { docId: doc, mode: null, context: context };
     }
 
     function resetContext() {

--- a/client/src/pages/dashboard/views/Invites.svelte
+++ b/client/src/pages/dashboard/views/Invites.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { dashboardState } from '../stores/DashboardState';
     import { inviteList } from '../../../pages/dashboard/stores/InviteStore.ts';
-    import { RowType, InvitePayload, IconColor, IconSize } from '../../../components/types.ts';
+    import { IconColor, IconSize } from '../../../components/types.ts';
 
     import Button from '../../../components/ui/Button.svelte';
     import InviteContext from '../../../components/ui/contextdrawer/InviteContext.svelte';
@@ -27,15 +27,15 @@
     let ctx = null as Context | null;
 
     function openContextMenu(email: Invitation['email'], office: Invitation['office']) {
-        ctx = {email: email, office: office, contextMenu: true, inviteModal: null}
+        ctx = { email: email, office: office, contextMenu: true, inviteModal: null };
     }
 
     function openRevokeInvite(email: Invitation['email'], office: Invitation['office']) {
-        ctx = {email: email, office: office, contextMenu: false, inviteModal: ActiveMenu.RevokeInvite}
+        ctx = { email: email, office: office, contextMenu: false, inviteModal: ActiveMenu.RevokeInvite };
     }
 
     function openCreateInvite() {
-        ctx = {email: null, office: null, contextMenu: null, inviteModal: ActiveMenu.CreateInvite}
+        ctx = { email: null, office: null, contextMenu: null, inviteModal: ActiveMenu.CreateInvite };
     }
     function resetContext() {
         ctx = null;

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -68,10 +68,7 @@
 
         <h2>Sent Documents</h2>
         {#each $documentOutbox.pending as entry (entry.doc)}
-            <SendRow 
-                {...entry}
-                iconSize={IconSize.Large}
-            />
+            <SendRow {...entry} iconSize={IconSize.Large} />
         {/each}
     {/await}
 {/if}
@@ -79,7 +76,7 @@
     <!-- Do not render anything! -->
 {:else if ctx.mode === Status.Register}
     <Modal title="Create Document" showModal on:close={resetContext}>
-        <CreateDocument on:done={resetContext}/>
+        <CreateDocument on:done={resetContext} />
     </Modal>
 {:else if ctx.context && ctx.docId !== null}
     <InboxContext 

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -55,7 +55,7 @@
         <p>Loading outbox...</p>
     {:then}
         <h2>Staged Registered Documents</h2>
-        {#each $documentOutbox.ready as {doc, category, creation, title} (doc)}
+        {#each $documentOutbox.ready as { doc, category, creation, title } (doc)}
             <RegisterRow 
                 {doc}
                 {category}

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -3,7 +3,7 @@
     import { dashboardState } from '../stores/DashboardState';
     import { documentOutbox } from '../stores/DocumentStore';
     
-    import { IconSize, Events, RowType, ContextPayload } from '../../../components/types';
+    import { IconSize } from '../../../components/types';
     import InboxContext from '../../../components/ui/contextdrawer/InboxContext.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import InsertSnapshot from '../../../components/ui/forms/document/InsertSnapshot.svelte';
@@ -25,6 +25,10 @@
 
     $: ({ currentOffice } = $dashboardState);
 
+    function openContext(doc: Document['id']) {
+        ctx = {docId: doc, mode: null, context: true};
+    }
+
     function openInsertSnapshot(doc: Document['id'], mode: Status) {
         ctx = {docId: doc, mode: mode, context: false}
     }
@@ -33,9 +37,6 @@
         ctx = {docId: null, mode: Status.Register, context: false};
     }
 
-    function openContext(doc: Document['id']) {
-        ctx = {docId: doc, mode: null, context: true};
-    }
 
     function resetContext() {
         ctx = null;

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -26,15 +26,15 @@
     $: ({ currentOffice } = $dashboardState);
 
     function openContext(doc: Document['id']) {
-        ctx = {docId: doc, mode: null, context: true};
+        ctx = { docId: doc, mode: null, context: true };
     }
 
     function openInsertSnapshot(doc: Document['id'], mode: Status) {
-        ctx = {docId: doc, mode: mode, context: false}
+        ctx = { docId: doc, mode: mode, context: false };
     }
 
     function openCreateDocument() {
-        ctx = {docId: null, mode: Status.Register, context: false};
+        ctx = { docId: null, mode: Status.Register, context: false };
     }
 
 

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -55,17 +55,23 @@
         <p>Loading outbox...</p>
     {:then}
         <h2>Staged Registered Documents</h2>
-        {#each $documentOutbox.ready as entry (entry.doc)}
+        {#each $documentOutbox.ready as {doc, category, creation, title} (doc)}
             <RegisterRow 
-                {...entry}
+                {doc}
+                {category}
+                {title}
+                {creation}
                 iconSize={IconSize.Large} 
-                on:overflowClick = {openContext.bind(null, entry.doc)}
+                on:overflowClick = {openContext.bind(null, doc)}
             />
         {/each}
 
         <h2>Sent Documents</h2>
         {#each $documentOutbox.pending as entry (entry.doc)}
-            <SendRow iconSize={IconSize.Large} {...entry} />
+            <SendRow 
+                {...entry}
+                iconSize={IconSize.Large}
+            />
         {/each}
     {/await}
 {/if}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -60,7 +60,7 @@
         <p>Loading staff page...</p>
     {:then}
         <h1>Staffs of {officeName}</h1>
-        {#each $staffList.filter(s => s.permission !== 0) as {id, name, email, permission, picture} (id)}
+        {#each $staffList.filter(s => s.permission !== 0) as { id, name, email, permission, picture } (id)}
             <PersonRowLocal
                 {id}
                 {email}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -2,6 +2,8 @@
     import { dashboardState } from '../stores/DashboardState';
     import { staffList } from '../stores/StaffStore';
     import { allOffices } from '../stores/OfficeStore';
+    import { Staff } from '~model/staff';
+    import { User } from '~model/user';
 
     import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
@@ -10,30 +12,45 @@
     import Modal from '../../../components/ui/Modal.svelte';
     import PersonContextLocal from '../../../components/ui/contextdrawer/PersonContextLocal.svelte';
 
+    enum ActiveMenu {
+        EditStaff,
+        RemoveStaff
+    }
+
+    interface Context {
+        id: Staff['user_id'],
+        office: Staff['office'],
+        email: User['email'],
+        permission: Staff['permission'],
+        showContext: boolean,
+        activeMenu: ActiveMenu | null;
+    }
+
     $: ({ currentOffice } = $dashboardState);
     $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
-    let showContextMenu = false;
-    let showLocalPermission = false;
-    let showRemoveStaff = false;
-    let currentContext = null as PersonPayload | null;
 
-    function overflowClickHandler(e: CustomEvent<PersonPayload>) {
-        currentContext = e.detail;
-        showContextMenu = true;
+    let ctx = null as Context | null;
+
+    function openContextMenu(id: Staff['user_id'], office: Staff['office'], email: User['email'], permission: Staff['permission']) {
+        ctx = {id: id, office: office, email: email, permission: permission, showContext: true, activeMenu: null}
     }
 
-    function contextMenuHandler(e: CustomEvent<PersonPayload>) {
-        switch (e.type) {
-            case Events.EditLocalPermission:
-                showLocalPermission = true;
-                break;
-            case Events.RemoveStaff:
-                showRemoveStaff = true;
-                break;
-            default: break;
-        }
+    function openEditStaff(ctxcpy: Context) {
+        ctxcpy.showContext = false;
+        ctxcpy.activeMenu = ActiveMenu.EditStaff;
+        ctx = ctxcpy;
     }
+
+    function openRemoveStaff(ctxcpy: Context) {
+        ctxcpy.showContext = false;
+        ctxcpy.activeMenu = ActiveMenu.RemoveStaff;
+        ctx = ctxcpy
+    }
+
+    function resetContext() {
+        ctx = null;
+    } 
 </script>
 
 {#if currentOffice === null}
@@ -48,35 +65,40 @@
                 {...staff}
                 office={currentOffice}
                 iconSize={IconSize.Large} 
-                on:overflowClick={overflowClickHandler} 
+                on:overflowClick={openContextMenu.bind(null, staff.id, currentOffice, staff.email, staff.permission)} 
             />
         {:else}
             No staff members exist in "{officeName}".
         {/each}
     {/await}
+{/if}
 
-    {#if currentContext?.ty === RowType.Person}
-        <PersonContextLocal
-            bind:show={showContextMenu}
-            payload={currentContext} 
-            on:editLocalPermission={contextMenuHandler}
-            on:removeStaff={contextMenuHandler}
+{#if ctx === null}
+    <!-- Do not render anything! -->
+{:else if ctx.activeMenu === ActiveMenu.EditStaff}
+    <Modal title="Edit Local Permissions" showModal>
+        <LocalPermissions
+            on:done={resetContext}
+            officeId={ctx.office}
+            permission={ctx.permission}
+            userId={ctx.id}
+            email={ctx.email}
         />
-    {/if}
-
-    <Modal title="Edit Local Permissions" bind:showModal={showLocalPermission}>
-        {#if currentContext === null}
-            Current user is not a staff of the selected office.
-        {:else}
-            <LocalPermissions payload={currentContext} />
-        {/if}
     </Modal>
-
-    <Modal title="Remove Staff" bind:showModal={showRemoveStaff}>
-        {#if currentContext === null}
-            Current user is not a staff of the selected office.
-        {:else}
-            <RemoveStaff payload={currentContext} />
-        {/if}
+{:else if ctx.activeMenu === ActiveMenu.RemoveStaff}
+    <Modal title="Remove Staff" showModal>
+        <RemoveStaff
+            on:done={resetContext}
+            id={ctx.id}
+            office={ctx.office} 
+            email={ctx.email}
+        />
     </Modal>
+{:else if ctx.showContext}
+    <PersonContextLocal
+        on:close={resetContext}
+        show
+        on:editLocalPermission={openEditStaff.bind(null, ctx)}
+        on:removeStaff={openRemoveStaff.bind(null, ctx)}
+    />
 {/if}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -60,12 +60,16 @@
         <p>Loading staff page...</p>
     {:then}
         <h1>Staffs of {officeName}</h1>
-        {#each $staffList.filter(s => s.permission !== 0) as staff (staff.id)}
+        {#each $staffList.filter(s => s.permission !== 0) as {id, name, email, permission, picture} (id)}
             <PersonRowLocal
-                {...staff}
+                {id}
+                {email}
+                {name}
+                {permission}
+                {picture}
                 office={currentOffice}
                 iconSize={IconSize.Large} 
-                on:overflowClick={openContextMenu.bind(null, staff.id, currentOffice, staff.email, staff.permission)} 
+                on:overflowClick={openContextMenu.bind(null, id, currentOffice, email, permission)} 
             />
         {:else}
             No staff members exist in "{officeName}".

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -5,7 +5,7 @@
     import { Staff } from '~model/staff';
     import { User } from '~model/user';
 
-    import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
+    import { IconSize } from '../../../components/types';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
@@ -33,7 +33,7 @@
     let ctx = null as Context | null;
 
     function openContextMenu(id: Staff['user_id'], office: Staff['office'], email: User['email'], permission: Staff['permission']) {
-        ctx = {id: id, office: office, email: email, permission: permission, showContext: true, activeMenu: null}
+        ctx = { id: id, office: office, email: email, permission: permission, showContext: true, activeMenu: null };
     }
 
     function openEditStaff(ctxcpy: Context) {
@@ -45,12 +45,12 @@
     function openRemoveStaff(ctxcpy: Context) {
         ctxcpy.showContext = false;
         ctxcpy.activeMenu = ActiveMenu.RemoveStaff;
-        ctx = ctxcpy
+        ctx = ctxcpy;
     }
 
     function resetContext() {
         ctx = null;
-    } 
+    }
 </script>
 
 {#if currentOffice === null}

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -35,11 +35,15 @@
     <p>Loading users page...</p>
 {:then}
     <h1>Users</h1>
-    {#each $userList.filter(u => u.permission !== 0) as user (user.id)}
+    {#each $userList.filter(u => u.permission !== 0) as {id, name, email, picture, permission} (id)}
         <PersonRowGlobal
-            {...user}
+            {id}
+            {name}
+            {email}
+            {picture}
+            {permission}
             iconSize={IconSize.Large} 
-            on:overflowClick={openContext.bind(null, user.id, user.permission)} 
+            on:overflowClick={openContext.bind(null, id, permission)} 
         />
     {:else}
         No users exist.

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -35,7 +35,7 @@
     <p>Loading users page...</p>
 {:then}
     <h1>Users</h1>
-    {#each $userList.filter(u => u.permission !== 0) as {id, name, email, picture, permission} (id)}
+    {#each $userList.filter(u => u.permission !== 0) as { id, name, email, picture, permission } (id)}
         <PersonRowGlobal
             {id}
             {name}

--- a/client/src/pages/dashboard/views/Users.svelte
+++ b/client/src/pages/dashboard/views/Users.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { userList } from '../stores/UserStore';
 
-    import { IconSize, PersonPayload, RowType, Events } from '../../../components/types';
+    import { IconSize } from '../../../components/types';
     import { User } from '~model/user';
     import PersonRowGlobal from '../../../components/ui/itemrow/PersonRowGlobal.svelte';
     import GlobalPermissions from '../../../components/ui/forms/permissions/GlobalPermissions.svelte';
@@ -18,10 +18,10 @@
     let ctx = null as Context | null;
 
     function openContext(id: User['id'], permissions: User['permission']) {
-        ctx = {id: id, permissions: permissions, context: true, showEdit: false}
+        ctx = { id: id, permissions: permissions, context: true, showEdit: false };
     }
 
-    function openEditGlobal(ctxcpy: ctx) {
+    function openEditGlobal(ctxcpy: Context) {
         ctxcpy.context = false;
         ctxcpy.showEdit = true;
         ctx = ctxcpy;


### PR DESCRIPTION
This PR extends the `state-machine` concept by @BastiDood in #79 and implements it in all pages that use this.
This also removes all the imports and dependencies that were used by the versions of dispatching dialogs.
PS: As an after-effect of these modifications - dialogs now close when the intended operations are done.