### PR TITLE
feat(client): Stores/Offline Error Handling

### DIFF
--- a/client/src/api/batch.ts
+++ b/client/src/api/batch.ts
@@ -14,6 +14,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Batch {
@@ -29,6 +30,7 @@ export namespace Batch {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/category.ts
+++ b/client/src/api/category.ts
@@ -8,6 +8,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 import { type AllCategories, AllCategoriesSchema } from '../../../model/src/api.ts';
@@ -26,6 +27,7 @@ export namespace Category {
             case StatusCodes.OK: return AllCategoriesSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -24,6 +24,7 @@ import {
     BadContentNegotiation,
     UnexpectedStatusCode,
     DeferredSnap,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Document {
@@ -64,6 +65,7 @@ export namespace Document {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -81,6 +81,7 @@ export namespace Document {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -96,6 +97,7 @@ export namespace Document {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -108,6 +110,7 @@ export namespace Document {
             case StatusCodes.OK: return PaperTrailSchema.array().parse(await res.json());
             case StatusCodes.BAD_REQUEST: throw new InvalidInput;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/error.ts
+++ b/client/src/api/error.ts
@@ -6,7 +6,7 @@ export class InsufficientPermissions extends Error {
 
 export class NoActiveOffice extends Error {
     constructor() {
-        super('no active office was selected')
+        super('no active office was selected');
     }
 }
 

--- a/client/src/api/error.ts
+++ b/client/src/api/error.ts
@@ -16,6 +16,11 @@ export class DeferredSnap extends Error {
     }
 }
 
+export class UncachedFetch extends Error {
+    constructor() {
+        super('resource was not cached and is unavailable offline');
+    }
+}
 export class InvalidSession extends Error {
     constructor() {
         super('invalid or expired session');

--- a/client/src/api/error.ts
+++ b/client/src/api/error.ts
@@ -4,6 +4,12 @@ export class InsufficientPermissions extends Error {
     }
 }
 
+export class NoActiveOffice extends Error {
+    constructor() {
+        super('no active office was selected')
+    }
+}
+
 export class InvalidInput extends Error {
     constructor() {
         super('invalid input');

--- a/client/src/api/error.ts
+++ b/client/src/api/error.ts
@@ -27,6 +27,7 @@ export class UncachedFetch extends Error {
         super('resource was not cached and is unavailable offline');
     }
 }
+
 export class InvalidSession extends Error {
     constructor() {
         super('invalid or expired session');

--- a/client/src/api/invite.ts
+++ b/client/src/api/invite.ts
@@ -9,6 +9,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Invite {
@@ -23,6 +24,7 @@ export namespace Invite {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -10,6 +10,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Metrics {
@@ -24,6 +25,7 @@ export namespace Metrics {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -38,6 +40,7 @@ export namespace Metrics {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -53,6 +56,7 @@ export namespace Metrics {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }
@@ -67,6 +71,7 @@ export namespace Metrics {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/office.ts
+++ b/client/src/api/office.ts
@@ -9,6 +9,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Office {
@@ -20,6 +21,7 @@ export namespace Office {
         switch (res.status) {
             case StatusCodes.OK: return AllOfficesSchema.parse(await res.json());
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/session.ts
+++ b/client/src/api/session.ts
@@ -6,6 +6,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Session {
@@ -18,6 +19,7 @@ export namespace Session {
             case StatusCodes.OK: return FullSessionSchema.parse(await res.json());
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/staff.ts
+++ b/client/src/api/staff.ts
@@ -10,6 +10,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace Staff {
@@ -24,6 +25,7 @@ export namespace Staff {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -8,6 +8,7 @@ import {
     InvalidSession,
     BadContentNegotiation,
     UnexpectedStatusCode,
+    UncachedFetch,
 } from './error.ts';
 
 export namespace User {
@@ -21,6 +22,7 @@ export namespace User {
             case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
             case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;
             default: throw new UnexpectedStatusCode;
         }
     }

--- a/client/src/pages/dashboard/stores/BatchStore.ts
+++ b/client/src/pages/dashboard/stores/BatchStore.ts
@@ -3,20 +3,18 @@ import { assert } from '../../../assert.ts';
 import { topToastMessage } from './ToastStore.ts';
 import { dashboardState } from './DashboardState.ts';
 import { Batch } from '../../../api/batch.ts';
-import { NoActiveOffice } from '../../../api/error.ts';
 
 export const earliestBatch = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return Batch.getEarliestBatch(currentOffice);
+            if (currentOffice !== null)
+                return Batch.getEarliestBatch(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve(null);
         }
+        return Promise.resolve(null);
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/BatchStore.ts
+++ b/client/src/pages/dashboard/stores/BatchStore.ts
@@ -1,14 +1,22 @@
 import { asyncDerived } from '@square/svelte-store';
+import { assert } from '../../../assert.ts';
+import { topToastMessage } from './ToastStore.ts';
 import { dashboardState } from './DashboardState.ts';
 import { Batch } from '../../../api/batch.ts';
+import { NoActiveOffice } from '../../../api/error.ts';
 
 export const earliestBatch = asyncDerived(
     dashboardState,
     $dashboardState => {
         const { currentOffice } = $dashboardState;
-        return currentOffice === null
-            ? Promise.resolve(null)
-            : Batch.getEarliestBatch(currentOffice);
+        try {
+            if (currentOffice === null) throw new NoActiveOffice;
+            return Batch.getEarliestBatch(currentOffice);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve(null);
+        }
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/CategoryStore.ts
+++ b/client/src/pages/dashboard/stores/CategoryStore.ts
@@ -1,9 +1,18 @@
 import { asyncReadable } from '@square/svelte-store';
-
+import { assert } from '../../../assert.ts';
 import { Category } from '../../../api/category.ts';
+import { topToastMessage } from './ToastStore.ts';
 
 export const categoryList = asyncReadable(
     { active: [], retire: [] },
-    Category.getAll,
+    async() => {
+        try {
+            return await Category.getAll();
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve({ active: [], retire: [] });
+        }
+    },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/CategoryStore.ts
+++ b/client/src/pages/dashboard/stores/CategoryStore.ts
@@ -5,14 +5,14 @@ import { topToastMessage } from './ToastStore.ts';
 
 export const categoryList = asyncReadable(
     { active: [], retire: [] },
-    async() => {
+    () => {
         try {
-            return await Category.getAll();
+            return Category.getAll();
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ active: [], retire: [] });
         }
+        return Promise.resolve({ active: [], retire: [] });
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/DocumentStore.ts
+++ b/client/src/pages/dashboard/stores/DocumentStore.ts
@@ -1,17 +1,22 @@
 import { asyncDerived } from '@square/svelte-store';
+import { assert } from '../../../assert.ts';
 import { dashboardState } from './DashboardState.ts';
 import { Document } from '../../../api/document';
+import { topToastMessage } from './ToastStore.ts';
+import { NoActiveOffice } from '../../../api/error.ts';
 
 export const documentInbox = asyncDerived(
     dashboardState,
     $dashboardState => {
         const { currentOffice } = $dashboardState;
-        return currentOffice === null
-            ? Promise.resolve({
-                pending: [],
-                accept: [],
-            })
-            : Document.getInbox(currentOffice);
+        try {
+            if (currentOffice === null) throw new NoActiveOffice;
+            return Document.getInbox(currentOffice);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve({ pending: [], accept: [] });
+        }
     },
     { reloadable: true }
 );
@@ -20,12 +25,14 @@ export const documentOutbox = asyncDerived(
     dashboardState,
     $dashboardState => {
         const { currentOffice } = $dashboardState;
-        return currentOffice === null
-            ? Promise.resolve({
-                pending: [],
-                ready: [],
-            })
-            : Document.getOutbox(currentOffice);
+        try {
+            if (currentOffice === null) throw new NoActiveOffice;
+            return Document.getOutbox(currentOffice);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve({ pending: [], ready: [] });
+        }
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/DocumentStore.ts
+++ b/client/src/pages/dashboard/stores/DocumentStore.ts
@@ -3,36 +3,33 @@ import { assert } from '../../../assert.ts';
 import { dashboardState } from './DashboardState.ts';
 import { Document } from '../../../api/document';
 import { topToastMessage } from './ToastStore.ts';
-import { NoActiveOffice } from '../../../api/error.ts';
 
 export const documentInbox = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return Document.getInbox(currentOffice);
+            if (currentOffice !== null)
+                return Document.getInbox(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ pending: [], accept: [] });
         }
+        return Promise.resolve({ pending: [], accept: [] });
     },
     { reloadable: true }
 );
 
 export const documentOutbox = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return Document.getOutbox(currentOffice);
+            if (currentOffice !== null)
+                return Document.getOutbox(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ pending: [], ready: [] });
         }
+        return Promise.resolve({ pending: [], ready: [] });
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/InviteStore.ts
+++ b/client/src/pages/dashboard/stores/InviteStore.ts
@@ -1,9 +1,21 @@
 import { asyncDerived } from '@square/svelte-store';
+import { assert } from '../../../assert.ts';
 import { dashboardState } from './DashboardState.ts';
+import { topToastMessage } from './ToastStore.ts';
 import { Invite } from '../../../api/invite.ts';
+import { NoActiveOffice } from '../../../api/error.ts';
 
 export const inviteList = asyncDerived(
     dashboardState,
-    ({ currentOffice }) => currentOffice === null ? Promise.resolve([]) : Invite.getList(currentOffice),
+    async({ currentOffice }) => {
+        try {
+            if (currentOffice === null) throw new NoActiveOffice;
+            return await Invite.getList(currentOffice);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve([]);
+        }
+    },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/InviteStore.ts
+++ b/client/src/pages/dashboard/stores/InviteStore.ts
@@ -3,19 +3,18 @@ import { assert } from '../../../assert.ts';
 import { dashboardState } from './DashboardState.ts';
 import { topToastMessage } from './ToastStore.ts';
 import { Invite } from '../../../api/invite.ts';
-import { NoActiveOffice } from '../../../api/error.ts';
 
 export const inviteList = asyncDerived(
     dashboardState,
-    async({ currentOffice }) => {
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return await Invite.getList(currentOffice);
+            if (currentOffice !== null)
+                return Invite.getList(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve([]);
         }
+        return Promise.resolve([]);
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/MetricStore.ts
+++ b/client/src/pages/dashboard/stores/MetricStore.ts
@@ -3,64 +3,61 @@ import { dashboardState } from './DashboardState.ts';
 import { Metrics } from '../../../api/metrics.ts';
 import { assert } from '../../../assert.ts';
 import { topToastMessage } from './ToastStore.ts';
-import { NoActiveOffice } from '../../../api/error.ts';
 
 export const userSummary = asyncReadable(
     { },
-    async() => {
+    () => {
         try {
-            return await Metrics.generateUserSummary();
+            return Metrics.generateUserSummary();
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ });
         }
+        return Promise.resolve({ });
     },
     { reloadable: true }
 );
 
 export const localSummary = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return Metrics.generateLocalSummary(currentOffice);
+            if (currentOffice !== null)
+                return Metrics.generateLocalSummary(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ });
         }
+        return Promise.resolve({ });
     },
     { reloadable: true }
 );
 
 export const globalSummary = asyncReadable(
     { },
-    async() => {
+    () => {
         try {
-            return await Metrics.generateGlobalSummary();
+            return Metrics.generateGlobalSummary();
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve({ });
         }
+        return Promise.resolve({ });
     },
     { reloadable: true }
 );
 
 export const barcodeSummary = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if (currentOffice === null) throw new NoActiveOffice;
-            return Metrics.generateBarcodeSummary(currentOffice);
+            if (currentOffice !== null)
+                return Metrics.generateBarcodeSummary(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve(null);
         }
+        return Promise.resolve(null);
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/StaffStore.ts
+++ b/client/src/pages/dashboard/stores/StaffStore.ts
@@ -1,14 +1,22 @@
 import { asyncDerived } from '@square/svelte-store';
 import { dashboardState } from './DashboardState.ts';
 import { Staff } from '../../../api/staff.ts';
+import { NoActiveOffice } from '../../../api/error.ts';
+import { assert } from '../../../assert.ts';
+import { topToastMessage } from './ToastStore.ts';
 
 export const staffList = asyncDerived(
     dashboardState,
     $dashboardState => {
         const { currentOffice } = $dashboardState;
-        return currentOffice === null
-            ? Promise.resolve([])
-            : Staff.get(currentOffice);
+        try {
+            if ( currentOffice === null ) throw new NoActiveOffice;
+            return Staff.get(currentOffice);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve([]);
+        }
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/StaffStore.ts
+++ b/client/src/pages/dashboard/stores/StaffStore.ts
@@ -1,22 +1,20 @@
 import { asyncDerived } from '@square/svelte-store';
 import { dashboardState } from './DashboardState.ts';
 import { Staff } from '../../../api/staff.ts';
-import { NoActiveOffice } from '../../../api/error.ts';
 import { assert } from '../../../assert.ts';
 import { topToastMessage } from './ToastStore.ts';
 
 export const staffList = asyncDerived(
     dashboardState,
-    $dashboardState => {
-        const { currentOffice } = $dashboardState;
+    ({ currentOffice }) => {
         try {
-            if ( currentOffice === null ) throw new NoActiveOffice;
-            return Staff.get(currentOffice);
+            if (currentOffice !== null)
+                return Staff.get(currentOffice);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve([]);
         }
+        return Promise.resolve([]);
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -8,14 +8,14 @@ import { topToastMessage } from './ToastStore.ts';
 
 export const userSession = asyncReadable(
     null,
-    async() => {
+    () => {
         try {
-            return await Session.getUser();
+            return Session.getUser();
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve(null);
         }
+        return Promise.resolve(null);
     },
     { reloadable: true }
 );
@@ -30,14 +30,14 @@ export const currentUser = derived(userSession, session => session === null ? nu
 
 export const userList = asyncReadable(
     [],
-    async() => {
+    () => {
         try {
-            return await User.getAll();
+            return User.getAll();
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
-            return Promise.resolve([]);
         }
+        return Promise.resolve([]);
     },
     { reloadable: true }
 );

--- a/client/src/pages/dashboard/stores/UserStore.ts
+++ b/client/src/pages/dashboard/stores/UserStore.ts
@@ -1,13 +1,22 @@
 import { asyncReadable, derived } from '@square/svelte-store';
-
+import { assert } from '../../../assert.ts';
 import { allOffices } from './OfficeStore.ts';
 import { Session } from '../../../api/session.ts';
 import { User as UserModel } from '~model/user.ts';
 import { User } from '../../../api/user.ts';
+import { topToastMessage } from './ToastStore.ts';
 
 export const userSession = asyncReadable(
     null,
-    Session.getUser,
+    async() => {
+        try {
+            return await Session.getUser();
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve(null);
+        }
+    },
     { reloadable: true }
 );
 
@@ -21,7 +30,15 @@ export const currentUser = derived(userSession, session => session === null ? nu
 
 export const userList = asyncReadable(
     [],
-    User.getAll,
+    async() => {
+        try {
+            return await User.getAll();
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+            return Promise.resolve([]);
+        }
+    },
     { reloadable: true }
 );
 

--- a/client/src/pages/sw.ts
+++ b/client/src/pages/sw.ts
@@ -118,10 +118,9 @@ async function handleFetch(req: Request): Promise<Response> {
     } catch (error) {
         assert(error instanceof TypeError);
         const maybeRes = await cache.match(req);
-        if (maybeRes instanceof Response)
-            return maybeRes;
-
-        return new Response(null, { status: StatusCodes.SERVICE_UNAVAILABLE });
+        return maybeRes instanceof Response
+            ? maybeRes
+            : new Response(null, { status: StatusCodes.SERVICE_UNAVAILABLE });
     }
 }
 

--- a/client/src/pages/sw.ts
+++ b/client/src/pages/sw.ts
@@ -118,8 +118,10 @@ async function handleFetch(req: Request): Promise<Response> {
     } catch (error) {
         assert(error instanceof TypeError);
         const maybeRes = await cache.match(req);
-        assert(maybeRes instanceof Response);
-        return maybeRes;
+        if (maybeRes instanceof Response) {
+            return maybeRes;
+        }
+        return new Response(null, { status: StatusCodes.SERVICE_UNAVAILABLE });
     }
 }
 

--- a/client/src/pages/sw.ts
+++ b/client/src/pages/sw.ts
@@ -118,9 +118,9 @@ async function handleFetch(req: Request): Promise<Response> {
     } catch (error) {
         assert(error instanceof TypeError);
         const maybeRes = await cache.match(req);
-        if (maybeRes instanceof Response) {
+        if (maybeRes instanceof Response)
             return maybeRes;
-        }
+
         return new Response(null, { status: StatusCodes.SERVICE_UNAVAILABLE });
     }
 }


### PR DESCRIPTION
This PR utilizes the Toasts implemented in #88 to notify the user of any network errors and expands on the capability of the Store to present errors to the user.

### Uncached Fetch
A new type of error that is raised when the user goes offline but the PWA is unable to perform in offline mode due to not being able to cache enough information.

### NoActiveOffice
The system now toasts when a user attempt to access a page without selecting an active office.

Blocked by #94 