### PR TITLE
feat: file upload and download

### DIFF
--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -30,16 +30,24 @@ import {
 export namespace Document {
     export async function create(
         oid: Office['id'],
-        doc: DocumentType,
+        data: File,
+        { id, title, category }: DocumentType,
         remark: Snapshot['remark'],
     ): Promise<Snapshot['creation'] | BarcodeAssignmentError> {
+        const body = new FormData;
+        body.set('id', id);
+        body.set('title', title);
+        body.set('category', category.toString());
+        body.set('remark', remark);
+        body.set('data', data);
+
         const res = await fetch(`/api/document?office=${oid}`, {
             credentials: 'same-origin',
             method: 'POST',
-            body: JSON.stringify({ ...doc, remark }),
+            body,
             headers: {
                 'Accept': 'application/json',
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/x-www-url-encoded',
             },
         });
         switch (res.status) {

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -30,7 +30,7 @@ import {
 export namespace Document {
     export async function create(
         oid: Office['id'],
-        data: File,
+        data: Blob,
         { id, title, category }: DocumentType,
         remark: Snapshot['remark'],
     ): Promise<Snapshot['creation'] | BarcodeAssignmentError> {
@@ -45,10 +45,7 @@ export namespace Document {
             credentials: 'same-origin',
             method: 'POST',
             body,
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/x-www-url-encoded',
-            },
+            headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
             case StatusCodes.CREATED: return SnapshotSchema.shape.creation.parse(await res.json());
@@ -62,9 +59,9 @@ export namespace Document {
         }
     }
 
-    export async function download(did: DocumentType['id']): Promise<Blob | null> {
+    export async function download(did: DocumentType['id'], mime: string): Promise<Blob | null> {
         const res = await fetch(`/api/document/download?doc=${did}`, {
-            headers: { 'Accept': 'application/pdf' },
+            headers: { 'Accept': mime },
         });
         switch (res.status) {
             case StatusCodes.OK: return res.blob();

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -62,6 +62,19 @@ export namespace Document {
         }
     }
 
+    export async function download(did: DocumentType['id']): Promise<Blob | null> {
+        const res = await fetch(`/api/document/download?doc=${did}`, {
+            headers: { 'Accept': 'application/pdf' },
+        });
+        switch (res.status) {
+            case StatusCodes.OK: return res.blob();
+            case StatusCodes.NOT_FOUND: return null;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
     export async function getDossier(oid: Office['id']): Promise<InboxEntry[]> {
         const res = await fetch(`/api/dossier?office=${oid}`, {
             credentials: 'same-origin',

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -86,6 +86,7 @@ CREATE TABLE document(
     id UUID NOT NULL REFERENCES barcode (code),
     category SMALLINT NOT NULL REFERENCES category (id),
     title VARCHAR(40) NOT NULL,
+    data BYTEA NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -87,6 +87,7 @@ CREATE TABLE document(
     category SMALLINT NOT NULL REFERENCES category (id),
     title VARCHAR(40) NOT NULL,
     data BYTEA NOT NULL,
+    mime VARCHAR(128) NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -299,24 +299,25 @@ Deno.test('full OAuth flow', async t => {
         // TODO: Test if we are indeed the minimum batch
         const snap = { evaluator: USER.id, remark: 'Hello', target: office };
         const uuid = crypto.randomUUID();
+        const blob = new Blob;
 
         // Dossier must be empty before assigning
         assertEquals(await db.getDossier(office), [ ]);
 
         // Non-existent barcode
-        assertEquals(await db.assignBarcodeToDocument({ ...doc, id: uuid }, snap), BarcodeAssignmentError.BarcodeNotFound);
+        assertEquals(await db.assignBarcodeToDocument(blob, { ...doc, id: uuid }, snap), BarcodeAssignmentError.BarcodeNotFound);
 
         // Non-existent category
-        assertEquals(await db.assignBarcodeToDocument({ ...doc, category: 0 }, snap), BarcodeAssignmentError.CategoryNotFound);
+        assertEquals(await db.assignBarcodeToDocument(blob, { ...doc, category: 0 }, snap), BarcodeAssignmentError.CategoryNotFound);
 
         // Non-existent evaluator
-        assertEquals(await db.assignBarcodeToDocument(doc, { ...snap, evaluator: uuid }), BarcodeAssignmentError.EvaluatorNotFound);
+        assertEquals(await db.assignBarcodeToDocument(blob, doc, { ...snap, evaluator: uuid }), BarcodeAssignmentError.EvaluatorNotFound);
 
         // Dossier must still be empty after erroneous assignments
         assertEquals(await db.getDossier(office), [ ]);
 
         // Successful assignment
-        const creation = await db.assignBarcodeToDocument(doc, snap);
+        const creation = await db.assignBarcodeToDocument(blob, doc, snap);
         assertInstanceOf(creation, Date);
 
         // Dossier must include the newly registered document
@@ -343,7 +344,7 @@ Deno.test('full OAuth flow', async t => {
         }]);
 
         // Use already assigned barcode
-        assertEquals(await db.assignBarcodeToDocument(doc, snap), BarcodeAssignmentError.AlreadyAssigned);
+        assertEquals(await db.assignBarcodeToDocument(blob, doc, snap), BarcodeAssignmentError.AlreadyAssigned);
 
         // Dossier must be unaffected after errneous assignment
         assertEquals(await db.getDossier(office), expected);
@@ -506,10 +507,10 @@ Deno.test('full OAuth flow', async t => {
     });
 
     await t.step('fully populate the batch - cleanup', async () => {
-
         // Assign barcodes to documents
         for (const other of others) {
             const result = await db.assignBarcodeToDocument(
+                new Blob,
                 {
                     id: other,
                     category,

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -299,7 +299,8 @@ Deno.test('full OAuth flow', async t => {
         // TODO: Test if we are indeed the minimum batch
         const snap = { evaluator: USER.id, remark: 'Hello', target: office };
         const uuid = crypto.randomUUID();
-        const blob = new Blob;
+        const bytes = Uint8Array.of(0, 1, 2, 3);
+        const blob = new Blob([bytes]);
 
         // Dossier must be empty before assigning
         assertEquals(await db.getDossier(office), [ ]);
@@ -319,6 +320,13 @@ Deno.test('full OAuth flow', async t => {
         // Successful assignment
         const creation = await db.assignBarcodeToDocument(blob, doc, snap);
         assertInstanceOf(creation, Date);
+
+        // Download the same file
+        const downloaded = await db.downloadFile(doc.id);
+        assertExists(downloaded);
+        assertStrictEquals(downloaded.type, 'application/octet-stream');
+        const downloadedBytes = new Uint8Array(await downloaded.arrayBuffer());
+        assertEquals(downloadedBytes, bytes);
 
         // Dossier must include the newly registered document
         const expected = [ { creation, doc: doc.id, title: doc.title, category: randomCategory } ];

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -323,13 +323,14 @@ export class Database {
      * @returns creation date if successfully added
      */
     async assignBarcodeToDocument(
+        blob: Blob,
         { id, category, title }: Document,
         { evaluator, remark, target }: Pick<Snapshot, 'evaluator' | 'remark' | 'target'>,
     ): Promise<Snapshot['creation'] | BarcodeAssignmentError> {
-        // TODO: Do Actual Document Upload
+        const bytes = new Uint8Array(await blob.arrayBuffer());
         try {
             const { rows: [ first, ...rest ] } = await this.#client
-                .queryObject`WITH results AS (INSERT INTO document (id,category,title) VALUES (${id},${category},${title}) RETURNING id)
+                .queryObject`WITH results AS (INSERT INTO document (id,category,title,file) VALUES (${id},${category},${title},${bytes}) RETURNING id)
                     INSERT INTO snapshot (doc,evaluator,remark,target) VALUES ((SELECT id from results),${evaluator},${remark},${target}) RETURNING creation`;
             assertStrictEquals(rest.length, 0);
             return SnapshotSchema.pick({ creation: true }).parse(first).creation;

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -18,7 +18,7 @@ interface UploadForm {
     category: Document['category'];
     title: Document['title'];
     remark: Snapshot['remark'];
-    file: Blob;
+    data: Blob;
 }
 
 function validateForm(form: FormData): UploadForm | null {
@@ -34,13 +34,13 @@ function validateForm(form: FormData): UploadForm | null {
     const remark = form.get('remark');
     if (typeof remark !== 'string') return null;
 
-    const file = form.get('file');
-    if (file instanceof Blob) return {
+    const data = form.get('data');
+    if (data instanceof Blob) return {
         id,
         category: parseInt(cat, 10),
         title,
         remark,
-        file,
+        data,
     };
 
     return null;
@@ -107,14 +107,14 @@ export async function handleCreateDocument(pool: Pool, req: Request, params: URL
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        const { file, remark, ...doc } = upload;
+        const { data, remark, ...doc } = upload;
         if ((staff.permission & Local.CreateDocument) === 0) {
             error(`[Document] User ${staff.user_id} cannot assign barcode ${doc.id} to document "${doc.title}"`);
             return new Response(null, { status: Status.Forbidden });
         }
 
         const barcodeResult: Date | BarcodeAssignmentError = await db.assignBarcodeToDocument(
-            file,
+            data,
             doc,
             {
                 remark,

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -88,7 +88,7 @@ export async function handleCreateDocument(pool: Pool, req: Request, params: URL
     }
 
     const [ mime, _ ] = parseMediaType(ct);
-    if (mime !== 'application/x-www-form-urlencoded') {
+    if (mime !== 'multipart/form-data') {
         error(`[Document] Content negotiation failed for session ${sid}`);
         return new Response(null, { status: Status.NotAcceptable });
     }

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -88,7 +88,7 @@ export async function handleCreateDocument(pool: Pool, req: Request, params: URL
     }
 
     const [ mime, _ ] = parseMediaType(ct);
-    if (mime !== 'application/json') {
+    if (mime !== 'application/x-www-form-urlencoded') {
         error(`[Document] Content negotiation failed for session ${sid}`);
         return new Response(null, { status: Status.NotAcceptable });
     }

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -14,7 +14,13 @@ import {
     handleDeleteCategory,
     handleActivateCategory,
 } from './api/category.ts';
-import { handleCreateDocument, handleGetDossier, handleGetInbox, handleGetPaperTrail, handleGetOutbox } from './api/document.ts';
+import {
+    handleCreateDocument,
+    handleGetDossier,
+    handleGetInbox,
+    handleGetPaperTrail,
+    handleGetOutbox
+} from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation, handleGetInvitedList } from './api/invite.ts';
 import {
     handleGenerateGlobalSummary,

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -16,6 +16,7 @@ import {
 } from './api/category.ts';
 import {
     handleCreateDocument,
+    handleDownloadDocument,
     handleGetDossier,
     handleGetInbox,
     handleGetPaperTrail,
@@ -45,6 +46,7 @@ async function handleGet(pool: Pool, req: Request) {
         case '/api/batch': return handleGetEarliestAvailableBatch(pool, req, searchParams);
         case '/api/categories': return handleGetAllCategories(pool, req);
         case '/api/document': return handleGetPaperTrail(pool, req, searchParams);
+        case '/api/document/download': return handleDownloadDocument(pool, req, searchParams);
         case '/api/dossier': return handleGetDossier(pool, req, searchParams);
         case '/api/inbox': return handleGetInbox(pool, req, searchParams);
         case '/api/invites': return handleGetInvitedList(pool, req, searchParams);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -245,6 +245,10 @@ Deno.test('full API integration test', async t => {
         // Dossier should be initially empty
         assertEquals(await Document.getDossier(oid), [ ]);
 
+        // Common file to be uploaded
+        const bytes = Uint8Array.of(65, 66, 67, 68);
+        const blob = new Blob([ bytes ], { type: 'text/plain' })
+
         for (const code of codes) {
             const batch = await Batch.getEarliestBatch(oid);
             assertInstanceOf(batch?.creation, Date);
@@ -253,6 +257,7 @@ Deno.test('full API integration test', async t => {
 
             const doc = await Document.create(
                 oid,
+                blob,
                 {
                     id: code,
                     title: 'Leave of Absence',
@@ -262,6 +267,11 @@ Deno.test('full API integration test', async t => {
             );
             assertInstanceOf(doc, Date);
             assert(new Date >= creation);
+
+            const downloaded = await Document.download(code, 'text/plain');
+            assertExists(downloaded);
+            const downloadedBytes = new Uint8Array(await downloaded.arrayBuffer());
+            assertEquals(downloadedBytes, bytes);
 
             const index: number = initial.codes.indexOf(code);
             assert(index >= 0);

--- a/tests/deno.lock
+++ b/tests/deno.lock
@@ -132,6 +132,12 @@
     "https://deno.land/x/zod@v3.21.4/index.ts": "d27aabd973613985574bc31f39e45cb5d856aa122ef094a9f38a463b8ef1a268",
     "https://deno.land/x/zod@v3.21.4/locales/en.ts": "a7a25cd23563ccb5e0eed214d9b31846305ddbcdb9c5c8f508b108943366ab4c",
     "https://deno.land/x/zod@v3.21.4/mod.ts": "64e55237cb4410e17d968cd08975566059f27638ebb0b86048031b987ba251c4",
-    "https://deno.land/x/zod@v3.21.4/types.ts": "b5d061babea250de14fc63764df5b3afa24f2b088a1d797fc060ba49a0ddff28"
+    "https://deno.land/x/zod@v3.21.4/types.ts": "b5d061babea250de14fc63764df5b3afa24f2b088a1d797fc060ba49a0ddff28",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/application-server-keys.js": "c1acc0b7d01dea6cd3fd93ca4f695800563a8ff1e70d7e4dbef50671c110ba8f",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/constants.js": "54d9f00dbd95210de4a85fad9e775a13777251e3131c9e7a09ddd526cc22b52c",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/jwt.js": "f8b494aec9d7a62f15493dea8a163d3f485501a262264085622bf23c16211bf4",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/payload.js": "94d5d6e38d54050cc4c90f0e983135757317319b31778a54de0d1935b4e0a205",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/util.js": "d99921b4ef25eeaf57607e17f2ece9d83af78145bb9c9bd9b59718f3a11ac6db",
+    "https://raw.githubusercontent.com/alastaircoote/webpush-webcrypto/177d4f04a02e41da5c41a445b5393c56e0d48971/lib/webpush.js": "b7fb8286bc74b92c540c3c644b32e27c387833c067643a73f6e983e494671771"
   }
 }


### PR DESCRIPTION
This PR implements the back-end infrastructure involved for file uploads and downloads. Specifically, we modify `POST /api/document` so that it no longer accepts `application/json`. Instead, it now requires `multipart/form-data` for file uploads. Given that we have file uploads, the document creation now also requires a `Blob` to be passed in as an argument.

Moreover, we have a new endpoint `GET /api/document/download`, which essentially downloads the stored blob in the database.