### PR TITLE
feat(client): add toast type

### DIFF
--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -28,7 +28,6 @@ export enum ToastType {
     Offline = 'offline'
 }
 
-
 export enum InputType {
     Text = 'text',
     Password = 'password',

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -21,6 +21,14 @@ export enum ButtonType {
     Danger = 'danger',
 }
 
+export enum ToastType {
+    Info = 'info',
+    Success = 'success',
+    Error = 'error',
+    Offline = 'offline'
+}
+
+
 export enum InputType {
     Text = 'text',
     Password = 'password',

--- a/client/src/components/ui/Toast.svelte
+++ b/client/src/components/ui/Toast.svelte
@@ -2,7 +2,6 @@
     import { topToastMessage } from '../../pages/dashboard/stores/ToastStore.ts';
 </script>
 
-<!-- TODO: For now, all toast messages are treated as errors. We should add a configuration for using different colors. -->
 {#if $topToastMessage !== null}
     {@const { title, body, type } = $topToastMessage}
     <div class={type}>

--- a/client/src/components/ui/Toast.svelte
+++ b/client/src/components/ui/Toast.svelte
@@ -4,17 +4,16 @@
 
 <!-- TODO: For now, all toast messages are treated as errors. We should add a configuration for using different colors. -->
 {#if $topToastMessage !== null}
-    {@const { title, body } = $topToastMessage}
-    <div>
-        <h3>❌ {title}</h3>
+    {@const { title, body, type } = $topToastMessage}
+    <div class={type}>
+        <h3>{title}</h3>
         <p>{body}</p>
     </div>
 {/if}
 
 <style>
     div {
-        background-color: var(--danger-bg);
-        border: 0.25rem solid var(--danger-color);
+        padding: var(--spacing-small);
         border-radius: var(--spacing-normal);
         bottom: 0;
         box-sizing: border-box;
@@ -25,5 +24,21 @@
 
     h3, p {
         margin: var(--spacing-small);
+    }
+
+    .info {
+        background-color: var(--primary-color);
+    }
+
+    .success {
+        background-color: var(--success-bg);
+    }
+
+    .error {
+        background-color: var(--danger-bg);
+    }
+
+    .offline {
+        background-color: var(--offline-color);
     }
 </style>

--- a/client/src/components/ui/forms/batch/GenerateBatch.svelte
+++ b/client/src/components/ui/forms/batch/GenerateBatch.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-    import { userSession } from '../../../../pages/dashboard/stores/UserStore.ts';
-</script>
-
-<p>You successfully generated a new batch as {$userSession?.email}</p>

--- a/client/src/components/ui/forms/category/CreateCategory.svelte
+++ b/client/src/components/ui/forms/category/CreateCategory.svelte
@@ -4,7 +4,7 @@
 
     import { assert } from '../../../../assert.ts';
     import { Category as Api } from '../../../../api/category.ts';
-    import { Events, IconColor } from '../../../types.ts';
+    import { Events, IconColor, ToastType } from '../../../types.ts';
 
     import { categoryList } from '../../../../pages/dashboard/stores/CategoryStore.ts';
     import { topToastMessage } from '../../../../pages/dashboard/stores/ToastStore.ts';
@@ -21,6 +21,7 @@
         try {
             await Api.create(name);
             await categoryList.reload?.();
+            topToastMessage.enqueue({ title: 'Category Creation', body: 'You successfully created a category.', type: ToastType.Success });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/category/CreateCategory.svelte
+++ b/client/src/components/ui/forms/category/CreateCategory.svelte
@@ -21,7 +21,11 @@
         try {
             await Api.create(name);
             await categoryList.reload?.();
-            topToastMessage.enqueue({ title: 'Category Creation', body: 'You successfully created a category.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Category Creation',
+                body: 'You successfully created a category.',
+            });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/category/RenameCategory.svelte
+++ b/client/src/components/ui/forms/category/RenameCategory.svelte
@@ -4,7 +4,7 @@
 
     import { assert } from '../../../../assert.ts';
     import { Category as Api } from '../../../../api/category.ts';
-    import { Events, IconColor } from '../../../types.ts';
+    import { Events, IconColor, ToastType } from '../../../types.ts';
 
     import { categoryList } from '../../../../pages/dashboard/stores/CategoryStore.ts';
     import { topToastMessage } from '../../../../pages/dashboard/stores/ToastStore.ts';
@@ -23,6 +23,7 @@
         try {
             await Api.rename({ id: cid, name: currName });
             await categoryList.reload?.();
+            topToastMessage.enqueue({ title: 'Category Rename', body: 'You successfully renamed a category.', type: ToastType.Success });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/category/RenameCategory.svelte
+++ b/client/src/components/ui/forms/category/RenameCategory.svelte
@@ -23,7 +23,11 @@
         try {
             await Api.rename({ id: cid, name: currName });
             await categoryList.reload?.();
-            topToastMessage.enqueue({ title: 'Category Rename', body: 'You successfully renamed a category.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Category Rename',
+                body: 'You successfully renamed a category.',
+            });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/document/CreateDocument.svelte
+++ b/client/src/components/ui/forms/document/CreateDocument.svelte
@@ -42,7 +42,11 @@
             await documentOutbox.reload?.();
             await reloadMetrics();
             dispatch(Events.Done);
-            topToastMessage.enqueue({ title: 'Document Creation', body: 'You have successfully created a document.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Document Creation',
+                body: 'You have successfully created a document.',
+            });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/document/CreateDocument.svelte
+++ b/client/src/components/ui/forms/document/CreateDocument.svelte
@@ -14,7 +14,7 @@
     import type { Category } from '../../../../.../../../../model/src/category.ts';
     import type { Document } from '../../../../.../../../../model/src/document.ts';
     import { Snapshot, Status } from '../../../../.../../../../model/src/snapshot.ts';
-    import { Events } from '../../../types.ts';
+    import { Events, ToastType } from '../../../types.ts';
     
     import { DeferredSnap } from '../../../../api/error.ts';
 
@@ -42,6 +42,7 @@
             await documentOutbox.reload?.();
             await reloadMetrics();
             dispatch(Events.Done);
+            topToastMessage.enqueue({ title: 'Document Creation', body: 'You have successfully created a document.', type: ToastType.Success });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -5,7 +5,7 @@
     import { Snapshot } from '../../../../api/snapshot.ts';
     import { Snapshot as SnapshotModel, Status } from '../../../../../../model/src/snapshot.ts';
     import { Office } from '../../../../../../model/src/office.ts';
-    import { IconColor, Events } from '../../../types.ts';
+    import { IconColor, Events, ToastType } from '../../../types.ts';
     import { Document } from '~model/document.ts';
 
     import { documentInbox, documentOutbox } from '../../../../pages/dashboard/stores/DocumentStore.ts';
@@ -35,9 +35,18 @@
         assert(node instanceof HTMLInputElement);
         assert(node.type === 'text');
 
-        if (status === Status.Receive) destOfficeId = userOfficeId;
-        if (status === Status.Terminate) destOfficeId = null;
-        else assert(destOfficeId !== null);
+        if (status === Status.Receive) {
+            destOfficeId = userOfficeId;
+            topToastMessage.enqueue({ title: 'Document Received', body: 'You have successfully received a document.', type: ToastType.Success });
+        }
+        else if (status === Status.Terminate) {
+            destOfficeId = null;
+            topToastMessage.enqueue({ title: 'Document Terminated', body: 'You have successfully terminated a document.', type: ToastType.Success });
+        }
+        else {
+            assert(destOfficeId !== null);
+            topToastMessage.enqueue({ title: 'Document Sent', body: 'You have successfully sent a document.', type: ToastType.Success });
+        }
         assert(docId);
 
         try {

--- a/client/src/components/ui/forms/document/InsertSnapshot.svelte
+++ b/client/src/components/ui/forms/document/InsertSnapshot.svelte
@@ -37,20 +37,30 @@
 
         if (status === Status.Receive) {
             destOfficeId = userOfficeId;
-            topToastMessage.enqueue({ title: 'Document Received', body: 'You have successfully received a document.', type: ToastType.Success });
-        }
-        else if (status === Status.Terminate) {
+            topToastMessage.enqueue({
+                title: 'Document Received',
+                body: 'You have successfully received a document.',
+                type: ToastType.Success,
+            });
+        } else if (status === Status.Terminate) {
             destOfficeId = null;
-            topToastMessage.enqueue({ title: 'Document Terminated', body: 'You have successfully terminated a document.', type: ToastType.Success });
-        }
-        else {
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Document Terminated',
+                body: 'You have successfully terminated a document.',
+            });
+        } else {
             assert(destOfficeId !== null);
-            topToastMessage.enqueue({ title: 'Document Sent', body: 'You have successfully sent a document.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Document Sent',
+                body: 'You have successfully sent a document.',
+            });
         }
         assert(docId);
 
         try {
-            await Snapshot.insert(userOfficeId,{
+            await Snapshot.insert(userOfficeId, {
                 doc: docId,
                 status,
                 remark: node.value,

--- a/client/src/components/ui/forms/invite/AddInvite.svelte
+++ b/client/src/components/ui/forms/invite/AddInvite.svelte
@@ -36,7 +36,11 @@
         try {
             await Invite.add({ email, office, permission });
             await inviteList.reload?.();
-            topToastMessage.enqueue({ title: 'Invite Creation', body: 'You have successfully invited a new staff.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Invite Creation',
+                body: 'You have successfully invited a new staff.',
+            });
             this.reset();
             dispatch(Events.Done);
         } catch (err) {

--- a/client/src/components/ui/forms/invite/AddInvite.svelte
+++ b/client/src/components/ui/forms/invite/AddInvite.svelte
@@ -3,10 +3,10 @@
     import { assert } from '../../../../assert.ts';
     import { Invite } from '../../../../api/invite.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
-    import { Events } from '../../../types.ts';
+    import { Events, ToastType } from '../../../types.ts';
 
-    import Button from '../../Button.svelte';
-    import Checkmark from '../../../icons/Checkmark.svelte';
+    import Button from '../../Button.svelte.ts';
+    import Checkmark from '../../../icons/Checkmark.svelte.ts';
 
     import { dashboardState } from '../../../../pages/dashboard/stores/DashboardState.ts';
     import { inviteList } from '../../../../pages/dashboard/stores/InviteStore.ts';
@@ -38,6 +38,7 @@
             await inviteList.reload?.();
             this.reset();
             dispatch(Events.Done);
+            topToastMessage.enqueue({ title: 'Invite Creation', body: 'You have successfully invited a new staff.', type: ToastType.Success });
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/invite/AddInvite.svelte
+++ b/client/src/components/ui/forms/invite/AddInvite.svelte
@@ -5,8 +5,8 @@
     import { Global } from '../../../../../../model/src/permission.ts';
     import { Events, ToastType } from '../../../types.ts';
 
-    import Button from '../../Button.svelte.ts';
-    import Checkmark from '../../../icons/Checkmark.svelte.ts';
+    import Button from '../../Button.svelte';
+    import Checkmark from '../../../icons/Checkmark.svelte';
 
     import { dashboardState } from '../../../../pages/dashboard/stores/DashboardState.ts';
     import { inviteList } from '../../../../pages/dashboard/stores/InviteStore.ts';

--- a/client/src/components/ui/forms/invite/AddInvite.svelte
+++ b/client/src/components/ui/forms/invite/AddInvite.svelte
@@ -36,9 +36,9 @@
         try {
             await Invite.add({ email, office, permission });
             await inviteList.reload?.();
+            topToastMessage.enqueue({ title: 'Invite Creation', body: 'You have successfully invited a new staff.', type: ToastType.Success });
             this.reset();
             dispatch(Events.Done);
-            topToastMessage.enqueue({ title: 'Invite Creation', body: 'You have successfully invited a new staff.', type: ToastType.Success });
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/invite/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/invite/RevokeInvite.svelte
@@ -25,12 +25,13 @@
         assert(email);
         assert(office);
         try {
-            await Invite.revoke({
-                office,
-                email,
-            });
+            await Invite.revoke({ office, email });
             await inviteList.reload?.();
-            topToastMessage.enqueue({ title: 'Invite Revocation', body: 'You have successfully revoked an invite.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Invite Revocation',
+                body: 'You have successfully revoked an invite.',
+            });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/invite/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/invite/RevokeInvite.svelte
@@ -6,13 +6,13 @@
     import { assert } from '../../../../assert.ts';
 
     import { Invite } from '../../../../api/invite.ts';
-    import { ButtonType, IconColor, Events } from '../../../types.ts';
+    import { ButtonType, IconColor, Events, ToastType } from '../../../types.ts';
 
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
 
     import { inviteList } from '../../../../pages/dashboard/stores/InviteStore.ts';
-    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore';
+    import { allOffices } from '../../../../pages/dashboard/stores/OfficeStore.ts';
     import { topToastMessage } from '../../../../pages/dashboard/stores/ToastStore.ts';
 
     export let email: Invitation['email'];
@@ -31,6 +31,7 @@
             });
             await inviteList.reload?.();
             dispatch(Events.Done);
+            topToastMessage.enqueue({ title: 'Invite Revocation', body: 'You have successfully revoked an invite.', type: ToastType.Success });
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/invite/RevokeInvite.svelte
+++ b/client/src/components/ui/forms/invite/RevokeInvite.svelte
@@ -30,8 +30,8 @@
                 email,
             });
             await inviteList.reload?.();
-            dispatch(Events.Done);
             topToastMessage.enqueue({ title: 'Invite Revocation', body: 'You have successfully revoked an invite.', type: ToastType.Success });
+            dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/components/ui/forms/office/EditOffice.svelte
+++ b/client/src/components/ui/forms/office/EditOffice.svelte
@@ -5,7 +5,7 @@
     import { Office as OfficeModel } from '~model/office.ts';
 
     import { Office } from '../../../../api/office.ts';
-    import { Events, IconColor } from '../../../types.ts';
+    import { Events, IconColor, ToastType } from '../../../types.ts';
 
     import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
@@ -30,6 +30,7 @@
                 name: currName,
             });
             await allOffices.reload?.();
+            topToastMessage.enqueue({ title: 'Office Edit', body: 'You successfully edited an office.', type: ToastType.Success });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/office/EditOffice.svelte
+++ b/client/src/components/ui/forms/office/EditOffice.svelte
@@ -30,7 +30,11 @@
                 name: currName,
             });
             await allOffices.reload?.();
-            topToastMessage.enqueue({ title: 'Office Edit', body: 'You successfully edited an office.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Office Edit',
+                body: 'You successfully edited an office.',
+            });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -22,7 +22,11 @@
         try {
             await Office.create(node.value);
             await userOffices.reload?.(); // Reloads all relevant stores
-            topToastMessage.enqueue({ title: 'Office Creation', body: 'You successfully created a new office.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Office Creation',
+                body: 'You successfully created a new office.',
+            });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -2,7 +2,7 @@
     import { assert } from '../../../../assert.ts';
 
     import { Office } from '../../../../api/office.ts';
-    import { IconColor } from '../../../types.ts';
+    import { IconColor, ToastType } from '../../../types.ts';
 
     import TextInput from '../../TextInput.svelte';
     import Button from '../../Button.svelte';
@@ -22,6 +22,7 @@
         try {
             await Office.create(node.value);
             await userOffices.reload?.(); // Reloads all relevant stores
+            topToastMessage.enqueue({ title: 'Office Creation', body: 'You successfully created a new office.', type: ToastType.Success });
             this.reset();
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -45,7 +45,11 @@
                 permission: permsVal,
             });
             await userList.reload?.();
-            topToastMessage.enqueue({ title: 'Global Permission', body: 'You have successfully edited a user\'s global permission.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Global Permission',
+                body: "You have successfully edited a user's global permission.",
+            });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -4,7 +4,7 @@
     import { assert } from '../../../../assert.ts';
 
     import { User as Api } from '../../../../api/user.ts';
-    import { IconColor, Events } from '../../../types.ts';
+    import { IconColor, Events, ToastType } from '../../../types.ts';
     import { Global } from '../../../../../../model/src/permission.ts';
     import { User } from '~model/user.ts';
 
@@ -45,6 +45,7 @@
                 permission: permsVal,
             });
             await userList.reload?.();
+            topToastMessage.enqueue({ title: 'Global Permission', body: "You have successfully edited a user's global permission.", type: ToastType.Success });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -48,7 +48,7 @@
             topToastMessage.enqueue({
                 type: ToastType.Success,
                 title: 'Global Permission',
-                body: "You have successfully edited a user's global permission.",
+                body: 'You have successfully edited a user\'s global permission.',
             });
             dispatch(Events.Done);
         } catch (err) {

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -45,7 +45,7 @@
                 permission: permsVal,
             });
             await userList.reload?.();
-            topToastMessage.enqueue({ title: 'Global Permission', body: "You have successfully edited a user's global permission.", type: ToastType.Success });
+            topToastMessage.enqueue({ title: 'Global Permission', body: 'You have successfully edited a user\'s global permission.', type: ToastType.Success });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -2,7 +2,7 @@
     import { createEventDispatcher } from 'svelte';
     import { checkPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
-    import { Events, IconColor } from '../../../types.ts';
+    import { Events, IconColor, ToastType } from '../../../types.ts';
     import { Staff as Api } from '../../../../api/staff.ts';
     import { Staff } from '~model/staff.ts';
     import { User } from '~model/user.ts';
@@ -50,6 +50,7 @@
 
             // Reload the staffList store
             await staffList.reload?.();
+            topToastMessage.enqueue({ title: 'Local Permission', body: "You have successfully edited a staff's local permission.", type: ToastType.Success });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -50,7 +50,7 @@
 
             // Reload the staffList store
             await staffList.reload?.();
-            topToastMessage.enqueue({ title: 'Local Permission', body: "You have successfully edited a staff's local permission.", type: ToastType.Success });
+            topToastMessage.enqueue({ title: 'Local Permission', body: 'You have successfully edited a staff\'s local permission.', type: ToastType.Success });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -50,7 +50,11 @@
 
             // Reload the staffList store
             await staffList.reload?.();
-            topToastMessage.enqueue({ title: 'Local Permission', body: 'You have successfully edited a staff\'s local permission.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Local Permission',
+                body: "You have successfully edited a staff's local permission.",
+            });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -53,7 +53,7 @@
             topToastMessage.enqueue({
                 type: ToastType.Success,
                 title: 'Local Permission',
-                body: "You have successfully edited a staff's local permission.",
+                body: 'You have successfully edited a staff\'s local permission.',
             });
             dispatch(Events.Done);
         } catch (err) {

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -26,7 +26,11 @@
                 user_id: id,
             });
             await staffList.reload?.();
-            topToastMessage.enqueue({ title: 'Staff Removal', body: 'You have successfully removed a staff.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Staff Removal',
+                body: 'You have successfully removed a staff.',
+            });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -11,7 +11,7 @@
     
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
-    import { ButtonType, Events, IconColor } from '../../../types.ts';
+    import { ButtonType, Events, IconColor, ToastType } from '../../../types.ts';
     
 
     export let id: Staff['user_id'];
@@ -26,6 +26,7 @@
                 user_id: id,
             });
             await staffList.reload?.();
+            topToastMessage.enqueue({ title: 'Staff Removal', body: 'You have successfully removed a staff.', type: ToastType.Success });
             dispatch(Events.Done);
         } catch (err) {
             assert(err instanceof Error);

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -20,7 +20,7 @@
     export let target: Snapshot['target'];
     export let creation: Snapshot['creation'];
 
-    $: targetName = target === null ? 'N/A' : ($allOffices[target] ?? 'Unknown');
+    $: targetName = target === null ? 'N/A' : $allOffices[target] ?? 'Unknown';
 </script>
 
 <RowTemplate

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -20,6 +20,7 @@
     export let target: Snapshot['target'];
     export let creation: Snapshot['creation'];
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     $: targetName = target === null ? 'N/A' : $allOffices[target] ?? 'Unknown';
 </script>
 

--- a/client/src/components/ui/itemrow/SendRow.svelte
+++ b/client/src/components/ui/itemrow/SendRow.svelte
@@ -4,7 +4,6 @@
     import type { Document } from '~model/document.ts';
     import type { Category } from '~model/category.ts';
     import type { Snapshot } from '~model/snapshot.ts';
-    import type { Office } from '~model/office.ts';
     import { goToTrackingPage } from './util.ts';
 
     import { allOffices } from '../../../pages/dashboard/stores/OfficeStore.ts';
@@ -13,18 +12,20 @@
     import RowTemplate from '../RowTemplate.svelte';
 
     import { IconSize } from '../../types.ts';
-    
+
     export let iconSize: IconSize;
     export let doc: Document['id'];
     export let category: Category['name'];
     export let title: Document['title'];
-    export let target: Office['id'];
+    export let target: Snapshot['target'];
     export let creation: Snapshot['creation'];
-    
-    $: targetName = $allOffices[target] ?? 'No office.';
+
+    $: targetName = target === null ? 'N/A' : ($allOffices[target] ?? 'Unknown');
 </script>
 
-<RowTemplate {iconSize} showOverflowIcon={false}
+<RowTemplate
+    {iconSize}
+    showOverflowIcon={false}
     on:rowContainerClick={() => goToTrackingPage(doc)}
 >
     <span class="chip category">{category}</span>

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -29,7 +29,11 @@
     }
     
     $: if (maybeOfficeName === null && $currentPage)
-        topToastMessage.enqueue({ title: 'No office selected', body: 'Please select an office to continue.', type: ToastType.Info });
+        topToastMessage.enqueue({
+            type: ToastType.Info,
+            title: 'No office selected',
+            body: 'Please select an office to continue.',
+        });
 </script>
 
 <svelte:head>

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -28,7 +28,7 @@
         deferredSnaps.onDocumentSync(evt);
     }
     
-    $: if (maybeOfficeName === null && $currentPage) 
+    $: if (maybeOfficeName === null && $currentPage)
         topToastMessage.enqueue({ title: 'No office selected', body: 'Please select an office to continue.', type: ToastType.Info });
 </script>
 

--- a/client/src/pages/dashboard/Dashboard.svelte
+++ b/client/src/pages/dashboard/Dashboard.svelte
@@ -6,10 +6,12 @@
     import { allOffices } from './stores/OfficeStore.ts';
     import { currentUser } from './stores/UserStore.ts';
     import { deferredSnaps } from './stores/DeferredStore.ts';
+    import { topToastMessage } from './stores/ToastStore.ts';
 
     import Toast from '../../components/ui/Toast.svelte';
     import TopBar from '../../components/ui/navigationbar/TopBar.svelte';
     import SideDrawer from '../../components/ui/navigationbar/SideDrawer.svelte';
+    import { ToastType } from '../../components/types.ts';
 
     import routes from './views/index.ts';
     import { register } from '../register.ts';
@@ -25,6 +27,9 @@
     function onSync(evt: MessageEvent<string>) {
         deferredSnaps.onDocumentSync(evt);
     }
+    
+    $: if (maybeOfficeName === null && $currentPage) 
+        topToastMessage.enqueue({ title: 'No office selected', body: 'Please select an office to continue.', type: ToastType.Info });
 </script>
 
 <svelte:head>

--- a/client/src/pages/dashboard/stores/DeferredStore.ts
+++ b/client/src/pages/dashboard/stores/DeferredStore.ts
@@ -32,7 +32,11 @@ export const deferredSnaps = {
     load: deferStore.load.bind(deferStore),
     onDocumentSync(evt: MessageEvent<string>) {
         assert(evt.data === 'sync');
-        topToastMessage.enqueue({ title: 'Background Syncronization', body: 'Syncronization successful.', type: ToastType.Offline });
+        topToastMessage.enqueue({
+            type: ToastType.Offline,
+            title: 'Background Syncronization',
+            body: 'Syncronization successful.',
+        });
         deferStore.reset?.();
     },
     upsert(insert: DeferredSnapshot) {

--- a/client/src/pages/dashboard/stores/DeferredStore.ts
+++ b/client/src/pages/dashboard/stores/DeferredStore.ts
@@ -8,6 +8,7 @@ import { assert } from '../../../assert.ts';
 import { DeferredFetchSchema } from '../../syncman.ts';
 
 import { topToastMessage } from './ToastStore.ts';
+import { ToastType } from '../../../components/types.ts';
 
 const deferStore = asyncWritable(
     [],
@@ -31,7 +32,7 @@ export const deferredSnaps = {
     load: deferStore.load.bind(deferStore),
     onDocumentSync(evt: MessageEvent<string>) {
         assert(evt.data === 'sync');
-        topToastMessage.enqueue({ title: 'Background Syncronization', body: 'Syncronization successful.' });
+        topToastMessage.enqueue({ title: 'Background Syncronization', body: 'Syncronization successful.', type: ToastType.Offline });
         deferStore.reset?.();
     },
     upsert(insert: DeferredSnapshot) {

--- a/client/src/pages/dashboard/stores/ToastStore.ts
+++ b/client/src/pages/dashboard/stores/ToastStore.ts
@@ -1,8 +1,10 @@
 import { writable } from '@square/svelte-store';
+import { ToastType } from '../../../components/types';
 
 export interface Toast {
     title: string;
     body: string;
+    type?: ToastType;
     timeout?: number;
 }
 
@@ -25,14 +27,15 @@ function bootstrap() {
         return;
     }
 
-    const { title, body, timeout } = first;
-    set({ title, body });
+    const { title, body, type, timeout } = first;
+    set({ title, body, type });
     handler = setTimeout(advance, timeout ?? 3000);
 }
 
 export const topToastMessage = {
     subscribe,
     enqueue(toast: Toast) {
+        toast.type ??= ToastType.Error;
         if (messages.push(toast) === 1) bootstrap();
     },
     dismiss() {

--- a/client/src/pages/dashboard/views/Barcodes.svelte
+++ b/client/src/pages/dashboard/views/Barcodes.svelte
@@ -29,7 +29,11 @@
             await Batch.generate(currentOffice as number);
             await earliestBatch.reload?.();
             await barcodeSummary.reload?.();
-            topToastMessage.enqueue({ title: 'Batch Generation', body: 'You successfully generated a batch of barcodes.', type: ToastType.Success });
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Batch Generation',
+                body: 'You successfully generated a batch of barcodes.',
+            });
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -41,8 +45,13 @@
         try {
             await earliestBatch.reload?.();
             if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
-                topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch.', type: ToastType.Info });
-            else showDownloadBatch = true;
+                topToastMessage.enqueue({
+                    type: ToastType.Info,
+                    title: 'No available barcodes',
+                    body: 'Please generate a new batch.',
+                });
+            else
+                showDownloadBatch = true;
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });

--- a/client/src/pages/dashboard/views/Barcodes.svelte
+++ b/client/src/pages/dashboard/views/Barcodes.svelte
@@ -8,18 +8,17 @@
     import { barcodeSummary } from '../stores/MetricStore.ts';
     import { allOffices } from '../stores/OfficeStore.ts';
 
-    import GenerateBatch from '../../../components/ui/forms/batch/GenerateBatch.svelte';
     import FetchEarliest from '../../../components/ui/forms/batch/FetchEarliest.svelte';
 
     import Download from '../../../components/icons/Download.svelte';
     import Add from '../../../components/icons/Add.svelte';
     import Button from '../../../components/ui/Button.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
+    import { ToastType } from '../../../components/types.ts';
 
     $: ({ currentOffice } = $dashboardState);
     $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
-    let showGenerateBatch = false;
     let showDownloadBatch = false;
 
     async function handleGenerate() {
@@ -30,7 +29,7 @@
             await Batch.generate(currentOffice as number);
             await earliestBatch.reload?.();
             await barcodeSummary.reload?.();
-            showGenerateBatch = true;
+            topToastMessage.enqueue({ title: 'Batch Generation', body: 'You successfully generated a batch of barcodes.', type: ToastType.Success });
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -41,7 +40,9 @@
         if (currentOffice === null) return;
         try {
             await earliestBatch.reload?.();
-            showDownloadBatch = true;
+            if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+                topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch.', type: ToastType.Info });
+            else showDownloadBatch = true;
         } catch (err) {
             assert(err instanceof Error);
             topToastMessage.enqueue({ title: err.name, body: err.message });
@@ -82,10 +83,6 @@
             
                 <Modal title="Download Stickers" bind:showModal={showDownloadBatch}>
                     <FetchEarliest />
-                </Modal>
-            
-                <Modal title="Generate New Batch" bind:showModal={showGenerateBatch}>
-                    <GenerateBatch />
                 </Modal>
             </main>
         {/if}

--- a/client/src/pages/dashboard/views/Barcodes.svelte
+++ b/client/src/pages/dashboard/views/Barcodes.svelte
@@ -40,7 +40,7 @@
         if (currentOffice === null) return;
         try {
             await earliestBatch.reload?.();
-            if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+            if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
                 topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch.', type: ToastType.Info });
             else showDownloadBatch = true;
         } catch (err) {

--- a/client/src/pages/dashboard/views/Categories.svelte
+++ b/client/src/pages/dashboard/views/Categories.svelte
@@ -16,6 +16,9 @@
     import CreateCategory from '../../../components/ui/forms/category/CreateCategory.svelte';
     import RenameCategory from '../../../components/ui/forms/category/RenameCategory.svelte';
 
+    import { topToastMessage } from '../stores/ToastStore.ts';
+    import { ToastType } from '../../../components/types.ts';
+
     enum ActiveMenu {
         Create,
         Activate,
@@ -33,10 +36,10 @@
     $: ({ active, retire } = $categoryList);
 
     async function activate(cid: Category['id']) {
-        // TODO: inform user about the result of the operation
         await Api.activate(cid);
         await categoryList.reload?.();
         ctx = null;
+        topToastMessage.enqueue({ title: 'Category Activation', body: 'You successfully activated a category.', type: ToastType.Success });
     }
 
     function resetContext() {
@@ -44,9 +47,9 @@
     }
 
     async function remove(cid: Category['id']) {
-        // TODO: inform user about the result of the operation
         await Api.remove(cid);
         await categoryList.reload?.();
+        topToastMessage.enqueue({ title: 'Category Removal', body: 'You successfully removed a category.', type: ToastType.Success });
         resetContext();
     }
 

--- a/client/src/pages/dashboard/views/Categories.svelte
+++ b/client/src/pages/dashboard/views/Categories.svelte
@@ -39,7 +39,11 @@
         await Api.activate(cid);
         await categoryList.reload?.();
         ctx = null;
-        topToastMessage.enqueue({ title: 'Category Activation', body: 'You successfully activated a category.', type: ToastType.Success });
+        topToastMessage.enqueue({
+            type: ToastType.Success,
+            title: 'Category Activation',
+            body: 'You successfully activated a category.',
+        });
     }
 
     function resetContext() {
@@ -49,7 +53,11 @@
     async function remove(cid: Category['id']) {
         await Api.remove(cid);
         await categoryList.reload?.();
-        topToastMessage.enqueue({ title: 'Category Removal', body: 'You successfully removed a category.', type: ToastType.Success });
+        topToastMessage.enqueue({
+            title: 'Category Removal',
+            body: 'You successfully removed a category.',
+            type: ToastType.Success,
+        });
         resetContext();
     }
 

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -39,7 +39,7 @@
     }
 
     function openCreateDocument() {
-        if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+        if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
             topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
         else
             ctx = { docId: null, mode: Status.Register, context: null };

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -15,6 +15,9 @@
     import InboxContext from '../../../components/ui/contextdrawer/InboxContext.svelte';
     import { loadAll } from '@square/svelte-store';
     import { deferredSnaps } from '../stores/DeferredStore.ts';
+    import { topToastMessage } from '../stores/ToastStore.ts';
+    import { ToastType } from '../../../components/types';
+    import { earliestBatch } from '../stores/BatchStore.ts';
 
     enum ActiveMenu {
         ContextInbox,
@@ -36,7 +39,10 @@
     }
 
     function openCreateDocument() {
-        ctx = { docId: null, mode: Status.Register, context: null };
+        if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+            topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
+        else
+            ctx = { docId: null, mode: Status.Register, context: null };
     }
 
     function setOpenedContext(doc: Document['id'], context: ActiveMenu) {

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -39,7 +39,11 @@
 
     function openCreateDocument() {
         if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
-            topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
+            topToastMessage.enqueue({
+                type: ToastType.Info,
+                title: 'No available barcodes',
+                body: 'Please generate a new batch',
+            });
         else
             ctx = { docId: null, mode: Status.Register, context: null };
     }

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -4,7 +4,7 @@
 
     import Button from '../../../components/ui/Button.svelte';
     import AcceptRow from '../../../components/ui/itemrow/AcceptRow.svelte';
-    import { IconSize } from '../../../components/types';
+    import { IconSize, ToastType } from '../../../components/types';
     import { Document } from '../../../../../model/src/document.ts';
     import { Status } from '../../../../../model/src/snapshot.ts';
     import InboxRow from '../../../components/ui/itemrow/InboxRow.svelte';
@@ -16,7 +16,6 @@
     import { loadAll } from '@square/svelte-store';
     import { deferredSnaps } from '../stores/DeferredStore.ts';
     import { topToastMessage } from '../stores/ToastStore.ts';
-    import { ToastType } from '../../../components/types';
     import { earliestBatch } from '../stores/BatchStore.ts';
 
     enum ActiveMenu {

--- a/client/src/pages/dashboard/views/Invites.svelte
+++ b/client/src/pages/dashboard/views/Invites.svelte
@@ -5,11 +5,11 @@
 
     import Button from '../../../components/ui/Button.svelte';
     import InviteContext from '../../../components/ui/contextdrawer/InviteContext.svelte';
-    import InviteForm from '../../../components/ui/forms/office/AddInvite.svelte';
+    import InviteForm from '../../../components/ui/forms/invite/AddInvite.svelte';
     import InviteRow from '../../../components/ui/itemrow/InviteRow.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import PersonAdd from '../../../components/icons/PersonAdd.svelte';
-    import RevokeInvite from '../../../components/ui/forms/office/RevokeInvite.svelte';
+    import RevokeInvite from '../../../components/ui/forms/invite/RevokeInvite.svelte';
     import { Invitation } from '~model/invitation.ts';
 
     enum ActiveMenu {

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -5,7 +5,7 @@
     import { earliestBatch } from '../stores/BatchStore.ts';
     import { topToastMessage } from '../stores/ToastStore.ts';
     
-    import { IconSize } from '../../../components/types';
+    import { IconSize, ToastType } from '../../../components/types';
     import InboxContext from '../../../components/ui/contextdrawer/InboxContext.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import InsertSnapshot from '../../../components/ui/forms/document/InsertSnapshot.svelte';
@@ -15,7 +15,6 @@
     import SendRow from '../../../components/ui/itemrow/SendRow.svelte';
     import { deferRegistrationCount } from '../stores/DeferredStore.ts';
     import { Document } from '../../../../../model/src/document.ts';
-    import { ToastType } from '../../../components/types';
 
     interface Context {
         docId: Document['id'] | null,

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -2,6 +2,8 @@
     import { Status } from '../../../../../model/src/snapshot.ts';
     import { dashboardState } from '../stores/DashboardState';
     import { documentOutbox } from '../stores/DocumentStore';
+    import { earliestBatch } from '../stores/BatchStore.ts';
+    import { topToastMessage } from '../stores/ToastStore.ts';
     
     import { IconSize } from '../../../components/types';
     import InboxContext from '../../../components/ui/contextdrawer/InboxContext.svelte';
@@ -13,6 +15,7 @@
     import SendRow from '../../../components/ui/itemrow/SendRow.svelte';
     import { deferRegistrationCount } from '../stores/DeferredStore.ts';
     import { Document } from '../../../../../model/src/document.ts';
+    import { ToastType } from '../../../components/types';
 
     interface Context {
         docId: Document['id'] | null,
@@ -33,7 +36,10 @@
     }
 
     function openCreateDocument() {
-        ctx = { docId: null, mode: Status.Register, context: false };
+        if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+            topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
+        else
+            ctx = { docId: null, mode: Status.Register, context: false };
     }
 
     function resetContext() {

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -36,7 +36,7 @@
     }
 
     function openCreateDocument() {
-        if ($earliestBatch === null || typeof $earliestBatch === 'undefined') 
+        if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
             topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
         else
             ctx = { docId: null, mode: Status.Register, context: false };

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -36,7 +36,11 @@
 
     function openCreateDocument() {
         if ($earliestBatch === null || typeof $earliestBatch === 'undefined')
-            topToastMessage.enqueue({ title: 'No available barcodes', body: 'Please generate a new batch', type: ToastType.Info });
+            topToastMessage.enqueue({
+                type: ToastType.Info,
+                title: 'No available barcodes',
+                body: 'Please generate a new batch',
+            });
         else
             ctx = { docId: null, mode: Status.Register, context: false };
     }

--- a/client/src/pages/vars.css
+++ b/client/src/pages/vars.css
@@ -10,6 +10,7 @@
     --danger-bg: #c24747;
     --dashboard-bg: #fff;
     --dashboard-sidedrawer: #b3b3b3;
+    --success-bg: #2A9A0A;
 
     --text-color: #000000;
     --font-size: 16px;


### PR DESCRIPTION
This PR aims to:
- Add Toast Types: Info, Success, Error, and Offline (default is Error)
- Prefer toast instead of confirmation modals
- Add toast reminder when office is not yet selected