### PR TITLE
feat: implement file download mechanism

### DIFF
--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -7,13 +7,13 @@ import {
     type AllInbox,
     type AllOutbox,
     type BarcodeAssignmentError,
+    type DocumentPaperTrail,
     type InboxEntry,
-    type PaperTrail,
     AllInboxSchema,
     AllOutboxSchema,
     BarcodeAssignmentErrorSchema,
+    DocumentPaperTrailSchema,
     InboxEntrySchema,
-    PaperTrailSchema,
 } from '../../../model/src/api.ts';
 import { type Snapshot, SnapshotSchema } from '../../../model/src/snapshot.ts';
 
@@ -122,12 +122,13 @@ export namespace Document {
         }
     }
 
-    export async function getPaperTrail(doc: DocumentType['id']): Promise<PaperTrail[]> {
+    export async function getPaperTrail(doc: DocumentType['id']): Promise<DocumentPaperTrail | null> {
         const res = await fetch(`/api/document?doc=${doc}`, {
             headers: { 'Accept': 'application/json' },
         });
         switch (res.status) {
-            case StatusCodes.OK: return PaperTrailSchema.array().parse(await res.json());
+            case StatusCodes.OK: return DocumentPaperTrailSchema.parse(await res.json());
+            case StatusCodes.NOT_FOUND: return null;
             case StatusCodes.BAD_REQUEST: throw new InvalidInput;
             case StatusCodes.NOT_ACCEPTABLE: throw new BadContentNegotiation;
             case StatusCodes.SERVICE_UNAVAILABLE: throw new UncachedFetch;

--- a/client/src/pages/Home.svelte
+++ b/client/src/pages/Home.svelte
@@ -13,6 +13,7 @@
     import QrScanner from '../components/ui/QRScanner.svelte';
     import { assert } from '../assert.ts';
     import PageUnavailable from '../components/ui/PageUnavailable.svelte';
+    import Toast from '../components/ui/Toast.svelte';
 
     const placeholderSrc = new URL('../assets/images/logo-background.png', import.meta.url);
     let showScan = false as boolean;
@@ -56,6 +57,7 @@
             <QrScanner on:onDocumentScan={scanHandler} />
         </Modal>
     {/if}
+    <Toast />
 </main>
 
 <style>

--- a/client/src/pages/dashboard/views/Inbox.svelte
+++ b/client/src/pages/dashboard/views/Inbox.svelte
@@ -71,7 +71,7 @@
 </script>    
 
 {#if currentOffice === null}
-    You must select an office before accessing the Inbox page.
+    <p>You must select an office before accessing the Inbox page.</p>
 {:else}
     <h1>Inbox</h1>
 

--- a/client/src/pages/dashboard/views/Outbox.svelte
+++ b/client/src/pages/dashboard/views/Outbox.svelte
@@ -63,8 +63,9 @@
         throw err;
     });
 </script>
+
 {#if currentOffice === null}
-    You must select an office before accessing the Outbox page.
+    <p>You must select an office before accessing the Outbox page.</p>
 {:else}
     <h1>Outbox</h1>
     

--- a/client/src/pages/track/Track.svelte
+++ b/client/src/pages/track/Track.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { PaperTrail } from '~model/api.ts';
+    import type { DocumentPaperTrail, PaperTrail } from '~model/api.ts';
     import { Document as DocumentModel } from '~model/document.ts';
     import { assert } from '../../assert.ts';
     import { Document } from '../../api/document.ts';
@@ -57,8 +57,6 @@
 
         if (typeof first !== 'undefined' && typeof last !== 'undefined')
             return {
-                title: first.title,
-                category: first.category,
                 documentFor: first.remark,
                 documentRemark: last.remark,
                 status: first.status,
@@ -69,8 +67,6 @@
         assert(typeof first !== 'undefined' && typeof last === 'undefined');
         const origin = first.target === null ? null : allOffices[first.target] ?? null;
         return {
-            title: first.title,
-            category: first.category,
             documentFor: first.remark,
             documentRemark: first.remark,
             status: first.status,
@@ -109,17 +105,17 @@
 <TopBar open />
 <main>
     {#if trackingNumber === null}
-        <p>No tracking number provided.</p>
+        No tracking number provided.
     {:else}
         {#await Promise.all([Document.getPaperTrail(trackingNumber), allOfficeReady])}
             Loading paper trail...
-        {:then [trail, _]}
-            {@const overview = renderOverview(trail, $allOffices)}
-            {#if overview === null}
+        {:then [meta, _]}
+            {#if meta === null}
                 <h1>Uh oh!</h1>
-                <p>Something went wrong. Kindly re-check your tracking id above.</p>
+                <p>Document does not exist.</p>
             {:else}
-                <h2>Document {overview.title}</h2>
+                {@const overview = renderOverview(meta.trail, $allOffices)}
+                <h2>Document {meta.title}</h2>
                 <Button on:click={subscribePushNotifications.bind(null, trackingNumber)}>
                     <Notification alt="Bell icon for subscribing to push notifications" /> Subscribe to Push Notifications
                 </Button>
@@ -132,36 +128,39 @@
                             <td></td>
                         </tr>
                         <tr>
-                            <td><b>Document Title</b></td>
-                            <td>{overview.title}</td>
-                        </tr>
-                        <tr>
                             <td><b>Document Tracking Number</b></td>
                             <td>{trackingNumber}</td>
                         </tr>
                         <tr>
+                            <td><b>Document Title</b></td>
+                            <td>{meta.title}</td>
+                        </tr>
+                        <tr>
                             <td><b>Document Category</b></td>
-                            <td>{overview.category}</td>
+                            <td>{meta.category}</td>
                         </tr>
-                        <tr>
-                            <td><b>Document For</b></td>
-                            <td>{overview.documentFor}</td>
-                        </tr>
-                        <tr>
-                            <td><b>Document Remarks</b></td>
-                            <td>{overview.documentRemark}</td>
-                        </tr>
-                        <tr>
-                            <td><b>Originating Office</b></td>
-                            <td>{overview.origin}</td>
-                        </tr>
-                        <tr>
-                            <td><b>Current Office</b></td>
-                            <td>{overview.current}</td>
-                        </tr>
-                        <tr>
-                            <td><b>Document Status</b></td>
-                            <td>{overview.status}</td>
+                        {#if overview !== null}
+                            <tr>
+                                <td><b>Document For</b></td>
+                                <td>{overview.documentFor}</td>
+                            </tr>
+                            <tr>
+                                <td><b>Document Remarks</b></td>
+                                <td>{overview.documentRemark}</td>
+                            </tr>
+                            <tr>
+                                <td><b>Originating Office</b></td>
+                                <td>{overview.origin}</td>
+                            </tr>
+                            <tr>
+                                <td><b>Current Office</b></td>
+                                <td>{overview.current}</td>
+                            </tr>
+                            <tr>
+                                <td><b>Document Status</b></td>
+                                <td>{overview.status}</td>
+                            </tr>
+                        {/if}
                     </table>
                     <br />
                     <table>
@@ -179,7 +178,7 @@
                             <td><b>Remarks</b></td>
                             <td><b>Evaluator</b></td>
                         </tr>
-                        {#each trail as { target, creation, status, remark, email }}
+                        {#each meta.trail as { target, creation, status, remark, email }}
                             <tr>
                                 <td>
                                     {#if target === null}

--- a/client/src/pages/track/Track.svelte
+++ b/client/src/pages/track/Track.svelte
@@ -115,8 +115,9 @@
                 <h1>Uh oh!</h1>
                 <p>Document does not exist.</p>
             {:else}
-                {@const overview = renderOverview(meta.trail, $allOffices)}
-                <h2>Document {meta.title}</h2>
+                {@const { title, category, mime, trail } = meta}
+                {@const overview = renderOverview(trail, $allOffices)}
+                <h2>Document {title}</h2>
                 <Button on:click={subscribePushNotifications.bind(null, trackingNumber)}>
                     <Notification alt="Bell icon for subscribing to push notifications" /> Subscribe to Push Notifications
                 </Button>
@@ -134,11 +135,11 @@
                         </tr>
                         <tr>
                             <td><b>Document Title</b></td>
-                            <td>{meta.title}</td>
+                            <td>{title}</td>
                         </tr>
                         <tr>
                             <td><b>Document Category</b></td>
-                            <td>{meta.category}</td>
+                            <td>{category}</td>
                         </tr>
                         {#if overview !== null}
                             <tr>
@@ -166,7 +167,7 @@
                     <br />
                     <table>
                         <td><p class="header-color"><b>File Attachment</b></p></td>
-                        <tr><a download type={meta.mime} href="/api/document/download?doc={trackingNumber}">{trackingNumber}</a></tr>
+                        <tr><a download type={mime} href="/api/document/download?doc={trackingNumber}">{trackingNumber}</a></tr>
                     </table>
                     <br />
                     <table>
@@ -179,7 +180,7 @@
                             <td><b>Remarks</b></td>
                             <td><b>Evaluator</b></td>
                         </tr>
-                        {#each meta.trail as { target, creation, status, remark, email }}
+                        {#each trail as { target, creation, status, remark, email }}
                             <tr>
                                 <td>
                                     {#if target === null}

--- a/client/src/pages/track/Track.svelte
+++ b/client/src/pages/track/Track.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import type { DocumentPaperTrail, PaperTrail } from '~model/api.ts';
+    import type { PaperTrail } from '~model/api.ts';
     import { Document as DocumentModel } from '~model/document.ts';
+
     import { assert } from '../../assert.ts';
     import { Document } from '../../api/document.ts';
     import { register } from '../register.ts';
@@ -165,7 +166,7 @@
                     <br />
                     <table>
                         <td><p class="header-color"><b>File Attachment</b></p></td>
-                        <tr>No file attachment.</tr>
+                        <tr><a download type={meta.mime} href="/api/document/download?doc={trackingNumber}">{trackingNumber}</a></tr>
                     </table>
                     <br />
                     <table>

--- a/client/src/pages/track/Track.svelte
+++ b/client/src/pages/track/Track.svelte
@@ -14,6 +14,7 @@
     import PrintQr from '../../components/ui/qr/PrintQr.svelte';
     import TopBar from '../../components/ui/navigationbar/TopBar.svelte';
     import PageUnavailable from '../../components/ui/PageUnavailable.svelte';
+    import Toast from '../../components/ui/Toast.svelte';
 
     $: ({ searchParams } = new URL(location.href));
     $: trackingNumber = searchParams.get('id');
@@ -201,6 +202,7 @@
             <PageUnavailable {err} />
         {/await}
     {/if}
+    <Toast />
 </main>
 
 <style>

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -41,10 +41,13 @@ export const BarcodeAssignmentErrorSchema = z.nativeEnum(BarcodeAssignmentError)
 
 export const PaperTrailSchema = SnapshotSchema
     .pick({ creation: true, status: true, target: true, remark: true })
-    .extend({ category: CategorySchema.shape.name })
-    .merge(DocumentSchema.pick({ title: true, mime: true }))
     .merge(UserSchema.pick({ name: true, email: true, picture: true }));
 export type PaperTrail = z.infer<typeof PaperTrailSchema>;
+
+export const DocumentPaperTrailSchema = DocumentSchema
+    .pick({ title: true, mime: true })
+    .extend({ trail: PaperTrailSchema.array(), category: CategorySchema.shape.name });
+export type DocumentPaperTrail = z.infer<typeof DocumentPaperTrailSchema>;
 
 export const InboxEntrySchema = SnapshotSchema
     .pick({ creation: true })

--- a/model/src/snapshot.ts
+++ b/model/src/snapshot.ts
@@ -18,7 +18,7 @@ export const SnapshotSchema = z.object({
     creation: z.coerce.date(),
     evaluator: UserSchema.shape.id,
     status: z.nativeEnum(Status),
-    remark: z.string().min(1).max(32),
+    remark: z.string().max(32),
     target: OfficeSchema.shape.id.nullable(),
 });
 

--- a/server/deno.json
+++ b/server/deno.json
@@ -32,6 +32,7 @@
         "cookie": "https://deno.land/std@0.185.0/http/cookie.ts",
         "content-type": "https://deno.land/std@0.185.0/media_types/content_type.ts",
         "datetime": "https://deno.land/std@0.185.0/datetime/constants.ts",
+        "extension": "https://deno.land/std@0.185.0/media_types/extension.ts",
         "hex": "https://deno.land/std@0.185.0/encoding/hex.ts",
         "http": "https://deno.land/std@0.185.0/http/http_status.ts",
         "log": "https://deno.land/std@0.185.0/log/mod.ts",

--- a/server/deno.lock
+++ b/server/deno.lock
@@ -83,6 +83,8 @@
     "https://deno.land/std@0.185.0/media_types/_db.ts": "7606d83e31f23ce1a7968cbaee852810c2cf477903a095696cdc62eaab7ce570",
     "https://deno.land/std@0.185.0/media_types/_util.ts": "916efbd30b6148a716f110e67a4db29d6949bf4048997b754415dd7e42c52378",
     "https://deno.land/std@0.185.0/media_types/content_type.ts": "ad98a5aa2d95f5965b2796072284258710a25e520952376ed432b0937ce743bc",
+    "https://deno.land/std@0.185.0/media_types/extension.ts": "a7cd28c9417143387cdfed27d4e8607ebcf5b1ec27eb8473d5b000144689fe65",
+    "https://deno.land/std@0.185.0/media_types/extensions_by_type.ts": "43806d6a52a0d6d965ada9d20e60a982feb40bc7a82268178d94edb764694fed",
     "https://deno.land/std@0.185.0/media_types/format_media_type.ts": "f5e1073c05526a6f5a516ac5c5587a1abd043bf1039c71cde1166aa4328c8baf",
     "https://deno.land/std@0.185.0/media_types/get_charset.ts": "18b88274796fda5d353806bf409eb1d2ddb3f004eb4bd311662c4cdd8ac173db",
     "https://deno.land/std@0.185.0/media_types/parse_media_type.ts": "835c4112e1357e95b4f10d7cdea5ae1801967e444f48673ff8f1cb4d32af9920",

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -339,18 +339,20 @@ Deno.test('full OAuth flow', async t => {
         assertStrictEquals(info.codes.length, 9);
 
         // Paper trail should contain one 
-        assertEquals(await db.getPaperTrail(doc.id), [{
-            status: Status.Register,
-            creation,
-            category: randomCategory,
-            remark: snap.remark,
-            target: snap.target,
-            name: USER.name,
-            email: USER.email,
-            picture: USER.picture,
+        assertEquals(await db.getPaperTrail(doc.id), {
             title: doc.title,
+            category: randomCategory,
             mime: 'application/octet-stream',
-        }]);
+            trail: [{
+                status: Status.Register,
+                creation,
+                remark: snap.remark,
+                target: snap.target,
+                name: USER.name,
+                email: USER.email,
+                picture: USER.picture,
+            }],
+        });
 
         // Use already assigned barcode
         assertEquals(await db.assignBarcodeToDocument(blob, doc, snap), BarcodeAssignmentError.AlreadyAssigned);
@@ -395,18 +397,15 @@ Deno.test('full OAuth flow', async t => {
         assertStrictEquals(result.eval, USER.name);
 
         await t.step('view latest snapshot in paper trail', async () => {
-            const trail = await db.getPaperTrail(chosen);
-            assertEquals(trail.at(-1), {
+            const meta = await db.getPaperTrail(chosen);
+            assertEquals(meta?.trail.at(-1), {
                 status: Status.Send,
                 creation: result.creation,
-                category: randomCategory,
                 remark: snapshot.remark,
                 target: office,
                 name: USER.name,
                 email: USER.email,
                 picture: USER.picture,
-                title: doc.title,
-                mime: 'application/octet-stream',
             });
         })
 

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -1,4 +1,5 @@
 import { getCookies } from 'cookie';
+import { extension } from 'extension';
 import { parseMediaType } from 'parse-media-type';
 import { Status } from 'http';
 import { error, info } from 'log';
@@ -173,7 +174,10 @@ export async function handleDownloadDocument(pool: Pool, req: Request, params: U
         }
 
         info(`[Document] File ${did} fetched from the database`);
-        return new Response(blob);
+        const ext = extension(blob.type);
+        return new Response(blob, {
+            headers: { 'Content-Disposition': `attachment; filename=${did}.${ext}` },
+        });
     } finally {
         db.release();
     }

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -174,7 +174,7 @@ export async function handleDownloadDocument(pool: Pool, req: Request, params: U
         }
 
         info(`[Document] File ${did} fetched from the database`);
-        const ext = extension(blob.type);
+        const ext = extension(blob.type) || 'bin';
         return new Response(blob, {
             headers: { 'Content-Disposition': `attachment; filename=${did}.${ext}` },
         });

--- a/tests/deno.json
+++ b/tests/deno.json
@@ -26,6 +26,7 @@
         "cookie": "https://deno.land/std@0.185.0/http/cookie.ts",
         "content-type": "https://deno.land/std@0.185.0/media_types/content_type.ts",
         "datetime": "https://deno.land/std@0.185.0/datetime/constants.ts",
+        "extension": "https://deno.land/std@0.185.0/media_types/extension.ts",
         "hex": "https://deno.land/std@0.185.0/encoding/hex.ts",
         "http": "https://deno.land/std@0.185.0/http/http_status.ts",
         "http-status-codes": "https://deno.land/x/http_status@v1.0.1/src/http_status_codes.ts",

--- a/tests/deno.lock
+++ b/tests/deno.lock
@@ -72,6 +72,8 @@
     "https://deno.land/std@0.185.0/media_types/_db.ts": "7606d83e31f23ce1a7968cbaee852810c2cf477903a095696cdc62eaab7ce570",
     "https://deno.land/std@0.185.0/media_types/_util.ts": "916efbd30b6148a716f110e67a4db29d6949bf4048997b754415dd7e42c52378",
     "https://deno.land/std@0.185.0/media_types/content_type.ts": "ad98a5aa2d95f5965b2796072284258710a25e520952376ed432b0937ce743bc",
+    "https://deno.land/std@0.185.0/media_types/extension.ts": "a7cd28c9417143387cdfed27d4e8607ebcf5b1ec27eb8473d5b000144689fe65",
+    "https://deno.land/std@0.185.0/media_types/extensions_by_type.ts": "43806d6a52a0d6d965ada9d20e60a982feb40bc7a82268178d94edb764694fed",
     "https://deno.land/std@0.185.0/media_types/format_media_type.ts": "f5e1073c05526a6f5a516ac5c5587a1abd043bf1039c71cde1166aa4328c8baf",
     "https://deno.land/std@0.185.0/media_types/get_charset.ts": "18b88274796fda5d353806bf409eb1d2ddb3f004eb4bd311662c4cdd8ac173db",
     "https://deno.land/std@0.185.0/media_types/parse_media_type.ts": "835c4112e1357e95b4f10d7cdea5ae1801967e444f48673ff8f1cb4d32af9920",


### PR DESCRIPTION
As its name suggests, this PR implements the file download button for the paper trail. Currently, the name of the downloaded file conforms to the `{id}.{mime}` format, where `id` is the document's UUID and `mime` is the file extension associated with its MIME type. In future PRs, we may consider using `document.title`, but that requires us to sanitize the file name in case it contains nasty characters.