### PR TITLE
fix(client): lengthen the timeout for offline notifications

### DIFF
--- a/client/src/stores/NetState.ts
+++ b/client/src/stores/NetState.ts
@@ -24,6 +24,7 @@ addEventListener('offline', async() => {
     topToastMessage.enqueue({
         title: 'Currently Offline',
         body: 'Actions will be cached and will be pushed when the connection returns.',
+        timeout: 8000,
         type: ToastType.Offline,
     });
 });


### PR DESCRIPTION
Currently, the offline toast message is too long to be read in three seconds. This PR extends the timeout to eight seconds.

Ideally, we should keep these timeouts long, anyway, but let the user dismiss it using a close button. The infrastructure for that is already implement using the `topToastMessage.dismiss` function. We just need to hook into the UI in future PRs.