### PR TITLE
feat(client): toast message sliding transitions

### DIFF
--- a/client/src/components/ui/Toast.svelte
+++ b/client/src/components/ui/Toast.svelte
@@ -14,7 +14,7 @@
 <style>
     div {
         padding: var(--spacing-small);
-        border-radius: var(--spacing-normal);
+        border-radius: var(--spacing-large) var(--spacing-large) 0 0;
         bottom: 0;
         box-sizing: border-box;
         color: white;

--- a/client/src/components/ui/Toast.svelte
+++ b/client/src/components/ui/Toast.svelte
@@ -1,10 +1,11 @@
 <script>
+    import { slide } from 'svelte/transition';
     import { topToastMessage } from '../../stores/ToastStore.ts';
 </script>
 
 {#if $topToastMessage !== null}
     {@const { title, body, type } = $topToastMessage}
-    <div class={type}>
+    <div class={type} transition:slide>
         <h3>{title}</h3>
         <p>{body}</p>
     </div>


### PR DESCRIPTION
This PR introduces sliding transitions to the toast messages. I also rounded out the corners of the toast message some more while removing the bottom rounded corners. This makes the sliding transition more "seamless" and "flush" with the bottom of the screen.