### PR TITLE
feat(server): implement endpoint for directly adding users to an office

### DIFF
--- a/client/src/api/staff.ts
+++ b/client/src/api/staff.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { type StaffMember, StaffMemberSchema } from '../../../model/src/api.ts';
 import type { Office } from '../../../model/src/office.ts';
 import type { Staff as StaffType } from '../../../model/src/staff.ts';
+import type { User } from '../../../model/src/user.ts';
 
 import {
     InsufficientPermissions,
@@ -14,6 +15,21 @@ import {
 } from './error.ts';
 
 export namespace Staff {
+    export async function add(uid: User['id'], oid: Office['id']): Promise<boolean> {
+        const res = await fetch(`/api/staff?user=${uid}&office=${oid}`, {
+            method: 'POST',
+            credentials: 'same-origin',
+        });
+        switch (res.status) {
+            case StatusCodes.CREATED: return true;
+            case StatusCodes.NOT_FOUND: return false;
+            case StatusCodes.BAD_REQUEST: throw new InvalidInput;
+            case StatusCodes.UNAUTHORIZED: throw new InvalidSession;
+            case StatusCodes.FORBIDDEN: throw new InsufficientPermissions;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+
     export async function get(oid: Office['id']): Promise<StaffMember[]> {
         const res = await fetch(`/api/staffs?office=${oid}`, {
             credentials: 'same-origin',

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -40,6 +40,7 @@ export enum BarcodeAssignmentError {
 export const BarcodeAssignmentErrorSchema = z.nativeEnum(BarcodeAssignmentError);
 
 export enum AddStaffError {
+    AlreadyExists,,
     UserNotExists,
     OfficeNotExists,
 }

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -39,6 +39,13 @@ export enum BarcodeAssignmentError {
 
 export const BarcodeAssignmentErrorSchema = z.nativeEnum(BarcodeAssignmentError);
 
+export enum AddStaffError {
+    UserNotExists,
+    OfficeNotExists,
+}
+
+export const AddStaffErrorSchema = z.nativeEnum(AddStaffError);
+
 export const PaperTrailSchema = SnapshotSchema
     .pick({ creation: true, status: true, target: true, remark: true })
     .merge(UserSchema.pick({ name: true, email: true, picture: true }));

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -40,7 +40,7 @@ export enum BarcodeAssignmentError {
 export const BarcodeAssignmentErrorSchema = z.nativeEnum(BarcodeAssignmentError);
 
 export enum AddStaffError {
-    AlreadyExists,,
+    AlreadyExists,
     UserNotExists,
     OfficeNotExists,
 }

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -165,6 +165,7 @@ Deno.test('full OAuth flow', async t => {
             assertStrictEquals(await db.addExistingUserAsStaff(noUser, newOffice), AddStaffError.UserNotExists);
             assertStrictEquals(await db.addExistingUserAsStaff(USER.id, 0), AddStaffError.OfficeNotExists);
             assertStrictEquals(await db.addExistingUserAsStaff(USER.id, newOffice), null);
+            assertStrictEquals(await db.addExistingUserAsStaff(USER.id, newOffice), AddStaffError.AlreadyExists);
         });
     });
 

--- a/server/src/database.test.ts
+++ b/server/src/database.test.ts
@@ -13,7 +13,11 @@ import { encode } from 'base64url';
 import { Pool } from 'postgres';
 import { validate } from 'uuid';
 
-import { BarcodeAssignmentError, InsertSnapshotError } from '~model/api.ts';
+import {
+    AddStaffError,
+    BarcodeAssignmentError,
+    InsertSnapshotError
+} from '~model/api.ts';
 import type { Category } from "~model/category.ts";
 import { Status } from '~model/snapshot.ts';
 
@@ -152,6 +156,15 @@ Deno.test('full OAuth flow', async t => {
 
             assertEquals(await db.getStaff(invite.office), [ { ...USER, permission: invite.permission } ]);
             assertArrayIncludes(await db.getUsers(), [ { ...USER, permission: 0 } ]);
+        });
+
+        await t.step('manual addition of staff', async () => {
+            const newOffice = await db.createOffice('DocTrack');
+            const noUser = crypto.randomUUID();
+            assertStrictEquals(await db.addExistingUserAsStaff(noUser, office), AddStaffError.UserNotExists);
+            assertStrictEquals(await db.addExistingUserAsStaff(noUser, newOffice), AddStaffError.UserNotExists);
+            assertStrictEquals(await db.addExistingUserAsStaff(USER.id, 0), AddStaffError.OfficeNotExists);
+            assertStrictEquals(await db.addExistingUserAsStaff(USER.id, newOffice), null);
         });
     });
 

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -4,7 +4,7 @@ import { range } from 'itertools';
 import { Pool, PoolClient, PostgresError } from 'postgres';
 import { z } from 'zod';
 
-import {
+import { AddStaffError,
     type AllCategories,
     type AllInbox,
     type AllOffices,
@@ -222,6 +222,30 @@ export class Database {
 
         await transaction.commit();
         return invites;
+    }
+
+    /** Adds a pre-existing user into an office as a new staff member. Returns `null` for success. */
+    async addExistingUserAsStaff(uid: User['id'], oid: Office['id']): Promise<AddStaffError | null> {
+        try {
+            const { rowCount } = await this.#client
+                .queryArray`INSERT INTO staff (user_id,office) VALUES (${uid},${oid})`;
+            assertStrictEquals(rowCount, 1);
+            return null;
+        } catch (err) {
+            assertInstanceOf(err, PostgresError);
+            const { fields: { code, constraint } } = err;
+            switch (code) {
+                case '23503':
+                    switch (constraint) {
+                        case 'staff_user_id_fkey': return AddStaffError.UserNotExists;
+                        case 'staff_office_fkey': return AddStaffError.OfficeNotExists;
+                        default: break;
+                    }
+                // falls through
+                default:
+                    unreachable();
+            }
+        }
     }
 
     /** Gets all of the current staff members for a given office ID. */

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -4,7 +4,7 @@ import { range } from 'itertools';
 import { Pool, PoolClient, PostgresError } from 'postgres';
 import { z } from 'zod';
 
-import { AddStaffError,
+import {
     type AllCategories,
     type AllInbox,
     type AllOffices,
@@ -17,6 +17,7 @@ import { AddStaffError,
     type MinBatch,
     type PushNotification,
     type StaffMember,
+    AddStaffError,
     AllCategoriesSchema,
     AllInboxSchema,
     AllOfficesSchema,
@@ -235,6 +236,9 @@ export class Database {
             assertInstanceOf(err, PostgresError);
             const { fields: { code, constraint } } = err;
             switch (code) {
+                case '23505':
+                    assertEquals(constraint, 'staff_pkey');
+                    return AddStaffError.AlreadyExists;
                 case '23503':
                     switch (constraint) {
                         case 'staff_user_id_fkey': return AddStaffError.UserNotExists;

--- a/server/src/routes/api/staff.ts
+++ b/server/src/routes/api/staff.ts
@@ -1,7 +1,7 @@
 import { unreachable } from 'asserts';
 import { getCookies } from 'cookie';
 import { Status } from 'http';
-import { error, info } from 'log';
+import { error, info, warning } from 'log';
 import { accepts } from 'negotiation';
 import { parseMediaType } from 'parse-media-type';
 import { Pool } from 'postgres';
@@ -66,6 +66,9 @@ export async function handleAddStaff(pool: Pool, req: Request, params: URLSearch
         }
 
         switch (result) {
+            case AddStaffError.AlreadyExists:
+                warning(`[Staff] User ${staff.user_id} attempted to add staff ${user} of office ${oid}`);
+                return new Response(null, { status: Status.Conflict });
             case AddStaffError.UserNotExists:
                 error(`[Staff] User ${staff.user_id} attempted to add non-existent user ${user} to office ${oid}`);
                 break;

--- a/server/src/routes/api/staff.ts
+++ b/server/src/routes/api/staff.ts
@@ -25,18 +25,12 @@ import { Database } from '../../database.ts';
  * - `401` => session ID is absent, expired, or otherwise malformed
  * - `403` => session has insufficient permissions
  * - `404` => user or office does not exist
- * - `406` => content negotiation failed
  */
 export async function handleAddStaff(pool: Pool, req: Request, params: URLSearchParams) {
     const { sid } = getCookies(req.headers);
     if (!sid) {
         error('[Staff] Absent session ID');
         return new Response(null, { status: Status.Unauthorized });
-    }
-
-    if (accepts(req, 'application/json') === undefined) {
-        error(`[Staff] Session ${sid} cannot accept JSON`);
-        return new Response(null, { status: Status.NotAcceptable });
     }
 
     const user = params.get('user');

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -32,7 +32,12 @@ import {
 import { handleCreateOffice, handleGetAllOffices, handleUpdateOffice } from './api/office.ts';
 import { handleGetUserFromSession } from './api/session.ts';
 import { handleInsertSnapshot } from './api/snapshot.ts';
-import { handleGetStaff, handleSetStaffPermissions, handleRemoveStaff } from './api/staff.ts';
+import {
+    handleAddStaff,
+    handleGetStaff,
+    handleSetStaffPermissions,
+    handleRemoveStaff,
+} from './api/staff.ts';
 import { handleGetUsers, handleSetUserPermissions } from './api/user.ts';
 import { handleHook, handleSubscribe, handleVapidPublicKey } from './api/vapid.ts';
 import { handleCallback, handleLogin, handleLogout } from './auth/mod.ts';
@@ -101,6 +106,7 @@ function handlePost(pool: Pool, req: Request) {
         case '/api/hook': return handleHook(pool, req, searchParams);
         case '/api/office': return handleCreateOffice(pool, req);
         case '/api/snapshot': return handleInsertSnapshot(pool, req, searchParams);
+        case '/api/staff': return handleAddStaff(pool, req, searchParams);
         case '/api/vapid': return handleSubscribe(pool, req);
         case '/auth/logout': return handleLogout(pool, req);
         default:


### PR DESCRIPTION
This PR introduces the new `POST /api/staff` endpoint, which takes in an office ID and a user ID (i.e., the primary key of the `staff` table) to insert a new `staff` instance into the database.

# Future Work
Add a button in the front end that invokes the `POST` endpoint. Note that due to this missing feature, #117 cannot be closed yet.