### PR TITLE
feat(client): implement deep permission-based visibility in side drawer

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -11,7 +11,7 @@ DocTrack is under the [GNU Affero General Public License v3.0](./LICENSE). Any f
 
 Files | Author(s) | License
 --- | --- | ---
-`client/src/assets/icons/bootstrap/*.svg` | [The Bootstrap Authors](https://github.com/twbs/icons) | [Apache 2.0](https://github.com/twbs/icons/blob/main/LICENSE.md)
+`client/src/assets/icons/bootstrap/*.svg` | [The Bootstrap Authors](https://github.com/twbs/icons) | [Apache 2.0](https://github.com/twbs/icons/blob/main/LICENSE)
 `client/src/assets/icons/carbon/*.svg` | [IBM Carbon Design System](https://github.com/carbon-design-system/carbon/tree/main/packages/icons) | [Apache 2.0](https://github.com/carbon-design-system/carbon/blob/main/LICENSE)
 `client/src/assets/icons/fluent/*.svg` | [Microsoft Fluent Design System](https://github.com/microsoft/fluentui-system-icons/tree/main/assets) | [MIT](https://github.com/microsoft/fluentui-system-icons/blob/main/LICENSE)
 

--- a/client/src/components/ui/MetricsSelect.svelte
+++ b/client/src/components/ui/MetricsSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { MetricsMode } from '../types.ts';
-    import { checkPerms } from './forms/permissions/util.ts';
+    import { checkAllPerms } from './forms/permissions/util.ts';
     import { Global, Local } from '../../../../model/src/permission.ts';
     import { User } from '~model/user.ts';
     import { Staff } from '~model/staff.ts';
@@ -12,10 +12,10 @@
 
 <select required bind:value>
     <option value={MetricsMode.User}>User Summary</option>
-    {#if checkPerms(localPermission, Local.ViewMetrics)}
+    {#if checkAllPerms(localPermission, Local.ViewMetrics)}
         <option value={MetricsMode.Local}>Local Summary</option>
     {/if}
-    {#if checkPerms(globalPermission, Global.ViewMetrics)}
+    {#if checkAllPerms(globalPermission, Global.ViewMetrics)}
         <option value={MetricsMode.Global}>Global Summary</option>
     {/if}
 </select>

--- a/client/src/components/ui/MetricsSelect.svelte
+++ b/client/src/components/ui/MetricsSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { MetricsMode } from '../types.ts';
-    import { checkAllPerms } from './forms/permissions/util.ts';
+    import { checkIfAllPerms } from './forms/permissions/util.ts';
     import { Global, Local } from '../../../../model/src/permission.ts';
     import { User } from '~model/user.ts';
     import { Staff } from '~model/staff.ts';
@@ -12,10 +12,10 @@
 
 <select required bind:value>
     <option value={MetricsMode.User}>User Summary</option>
-    {#if checkAllPerms(localPermission, Local.ViewMetrics)}
+    {#if checkIfAllPerms(localPermission, Local.ViewMetrics)}
         <option value={MetricsMode.Local}>Local Summary</option>
     {/if}
-    {#if checkAllPerms(globalPermission, Global.ViewMetrics)}
+    {#if checkIfAllPerms(globalPermission, Global.ViewMetrics)}
         <option value={MetricsMode.Global}>Global Summary</option>
     {/if}
 </select>

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
-    import { checkPerms } from './util.ts';
+    import { checkAllPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
 
     import { topToastMessage } from '../../../../stores/ToastStore.ts';
@@ -67,7 +67,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateOffice}
-            checked={checkPerms(permission, Global.CreateOffice)}
+            checked={checkAllPerms(permission, Global.CreateOffice)}
         />
         Create Office
     </label>
@@ -76,7 +76,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateOffice}
-            checked={checkPerms(permission, Global.UpdateOffice)}
+            checked={checkAllPerms(permission, Global.UpdateOffice)}
         />
         Update Office
     </label>
@@ -85,7 +85,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateUser}
-            checked={checkPerms(permission, Global.UpdateUser)}
+            checked={checkAllPerms(permission, Global.UpdateUser)}
         />
         Update User
     </label>
@@ -94,7 +94,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateCategory}
-            checked={checkPerms(permission, Global.CreateCategory)}
+            checked={checkAllPerms(permission, Global.CreateCategory)}
         />
         Create Category
     </label>
@@ -103,7 +103,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateCategory}
-            checked={checkPerms(permission, Global.UpdateCategory)}
+            checked={checkAllPerms(permission, Global.UpdateCategory)}
         />
         Update Category
     </label>
@@ -112,7 +112,7 @@
             type="checkbox"
             name="perms"
             value={Global.DeleteCategory}
-            checked={checkPerms(permission, Global.DeleteCategory)}
+            checked={checkAllPerms(permission, Global.DeleteCategory)}
         />
         Delete Category
     </label>
@@ -121,7 +121,7 @@
             type="checkbox"
             name="perms"
             value={Global.ActivateCategory}
-            checked={checkPerms(permission, Global.ActivateCategory)}
+            checked={checkAllPerms(permission, Global.ActivateCategory)}
         />
         Activate Category
     </label>
@@ -130,7 +130,7 @@
             type="checkbox"
             name="perms"
             value={Global.ViewMetrics}
-            checked={checkPerms(permission, Global.ViewMetrics)}
+            checked={checkAllPerms(permission, Global.ViewMetrics)}
         />
         View Metrics
     </label>

--- a/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/GlobalPermissions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
-    import { checkAllPerms } from './util.ts';
+    import { checkIfAllPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
 
     import { topToastMessage } from '../../../../stores/ToastStore.ts';
@@ -67,7 +67,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateOffice}
-            checked={checkAllPerms(permission, Global.CreateOffice)}
+            checked={checkIfAllPerms(permission, Global.CreateOffice)}
         />
         Create Office
     </label>
@@ -76,7 +76,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateOffice}
-            checked={checkAllPerms(permission, Global.UpdateOffice)}
+            checked={checkIfAllPerms(permission, Global.UpdateOffice)}
         />
         Update Office
     </label>
@@ -85,7 +85,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateUser}
-            checked={checkAllPerms(permission, Global.UpdateUser)}
+            checked={checkIfAllPerms(permission, Global.UpdateUser)}
         />
         Update User
     </label>
@@ -94,7 +94,7 @@
             type="checkbox"
             name="perms"
             value={Global.CreateCategory}
-            checked={checkAllPerms(permission, Global.CreateCategory)}
+            checked={checkIfAllPerms(permission, Global.CreateCategory)}
         />
         Create Category
     </label>
@@ -103,7 +103,7 @@
             type="checkbox"
             name="perms"
             value={Global.UpdateCategory}
-            checked={checkAllPerms(permission, Global.UpdateCategory)}
+            checked={checkIfAllPerms(permission, Global.UpdateCategory)}
         />
         Update Category
     </label>
@@ -112,7 +112,7 @@
             type="checkbox"
             name="perms"
             value={Global.DeleteCategory}
-            checked={checkAllPerms(permission, Global.DeleteCategory)}
+            checked={checkIfAllPerms(permission, Global.DeleteCategory)}
         />
         Delete Category
     </label>
@@ -121,7 +121,7 @@
             type="checkbox"
             name="perms"
             value={Global.ActivateCategory}
-            checked={checkAllPerms(permission, Global.ActivateCategory)}
+            checked={checkIfAllPerms(permission, Global.ActivateCategory)}
         />
         Activate Category
     </label>
@@ -130,7 +130,7 @@
             type="checkbox"
             name="perms"
             value={Global.ViewMetrics}
-            checked={checkAllPerms(permission, Global.ViewMetrics)}
+            checked={checkIfAllPerms(permission, Global.ViewMetrics)}
         />
         View Metrics
     </label>

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
-    import { checkPerms } from './util.ts';
+    import { checkAllPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
     import { Events, IconColor, ToastType } from '../../../types.ts';
     import { Staff as Api } from '../../../../api/staff.ts';
@@ -72,7 +72,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={checkPerms(permission, Local.AddStaff)}
+            checked={checkAllPerms(permission, Local.AddStaff)}
         />
         Add Staff
     </label>
@@ -81,7 +81,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={checkPerms(permission, Local.RemoveStaff)}
+            checked={checkAllPerms(permission, Local.RemoveStaff)}
         />
         Remove Staff
     </label>
@@ -90,7 +90,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={checkPerms(permission, Local.UpdateStaff)}
+            checked={checkAllPerms(permission, Local.UpdateStaff)}
         />
         Update Staff
     </label>
@@ -99,7 +99,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={checkPerms(permission, Local.AddInvite)}
+            checked={checkAllPerms(permission, Local.AddInvite)}
         />
         Add Invite
     </label>
@@ -108,7 +108,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={checkPerms(permission, Local.RevokeInvite)}
+            checked={checkAllPerms(permission, Local.RevokeInvite)}
         />
         Revoke Invite
     </label>
@@ -117,7 +117,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={checkPerms(permission, Local.ViewBatch)}
+            checked={checkAllPerms(permission, Local.ViewBatch)}
         />
         View Batch
     </label>
@@ -126,7 +126,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={checkPerms(permission, Local.GenerateBatch)}
+            checked={checkAllPerms(permission, Local.GenerateBatch)}
         />
         Generate Batch
     </label>
@@ -135,7 +135,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={checkPerms(permission, Local.InvalidateBatch)}
+            checked={checkAllPerms(permission, Local.InvalidateBatch)}
         />
         Invalidate Batch
     </label>
@@ -144,7 +144,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={checkPerms(permission, Local.CreateDocument)}
+            checked={checkAllPerms(permission, Local.CreateDocument)}
         />
         Create Document
     </label>
@@ -153,7 +153,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={checkPerms(permission, Local.InsertSnapshot)}
+            checked={checkAllPerms(permission, Local.InsertSnapshot)}
         />
         Insert Snapshot
     </label>
@@ -162,7 +162,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={checkPerms(permission, Local.ViewMetrics)}
+            checked={checkAllPerms(permission, Local.ViewMetrics)}
         />
         View Metrics
     </label>
@@ -171,7 +171,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={checkPerms(permission, Local.ViewInbox)}
+            checked={checkAllPerms(permission, Local.ViewInbox)}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/permissions/LocalPermissions.svelte
+++ b/client/src/components/ui/forms/permissions/LocalPermissions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
-    import { checkAllPerms } from './util.ts';
+    import { checkIfAllPerms } from './util.ts';
     import { assert } from '../../../../assert.ts';
     import { Events, IconColor, ToastType } from '../../../types.ts';
     import { Staff as Api } from '../../../../api/staff.ts';
@@ -72,7 +72,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddStaff}
-            checked={checkAllPerms(permission, Local.AddStaff)}
+            checked={checkIfAllPerms(permission, Local.AddStaff)}
         />
         Add Staff
     </label>
@@ -81,7 +81,7 @@
             type="checkbox"
             name="perms"
             value={Local.RemoveStaff}
-            checked={checkAllPerms(permission, Local.RemoveStaff)}
+            checked={checkIfAllPerms(permission, Local.RemoveStaff)}
         />
         Remove Staff
     </label>
@@ -90,7 +90,7 @@
             type="checkbox"
             name="perms"
             value={Local.UpdateStaff}
-            checked={checkAllPerms(permission, Local.UpdateStaff)}
+            checked={checkIfAllPerms(permission, Local.UpdateStaff)}
         />
         Update Staff
     </label>
@@ -99,7 +99,7 @@
             type="checkbox"
             name="perms"
             value={Local.AddInvite}
-            checked={checkAllPerms(permission, Local.AddInvite)}
+            checked={checkIfAllPerms(permission, Local.AddInvite)}
         />
         Add Invite
     </label>
@@ -108,7 +108,7 @@
             type="checkbox"
             name="perms"
             value={Local.RevokeInvite}
-            checked={checkAllPerms(permission, Local.RevokeInvite)}
+            checked={checkIfAllPerms(permission, Local.RevokeInvite)}
         />
         Revoke Invite
     </label>
@@ -117,7 +117,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewBatch}
-            checked={checkAllPerms(permission, Local.ViewBatch)}
+            checked={checkIfAllPerms(permission, Local.ViewBatch)}
         />
         View Batch
     </label>
@@ -126,7 +126,7 @@
             type="checkbox"
             name="perms"
             value={Local.GenerateBatch}
-            checked={checkAllPerms(permission, Local.GenerateBatch)}
+            checked={checkIfAllPerms(permission, Local.GenerateBatch)}
         />
         Generate Batch
     </label>
@@ -135,7 +135,7 @@
             type="checkbox"
             name="perms"
             value={Local.InvalidateBatch}
-            checked={checkAllPerms(permission, Local.InvalidateBatch)}
+            checked={checkIfAllPerms(permission, Local.InvalidateBatch)}
         />
         Invalidate Batch
     </label>
@@ -144,7 +144,7 @@
             type="checkbox"
             name="perms"
             value={Local.CreateDocument}
-            checked={checkAllPerms(permission, Local.CreateDocument)}
+            checked={checkIfAllPerms(permission, Local.CreateDocument)}
         />
         Create Document
     </label>
@@ -153,7 +153,7 @@
             type="checkbox"
             name="perms"
             value={Local.InsertSnapshot}
-            checked={checkAllPerms(permission, Local.InsertSnapshot)}
+            checked={checkIfAllPerms(permission, Local.InsertSnapshot)}
         />
         Insert Snapshot
     </label>
@@ -162,7 +162,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewMetrics}
-            checked={checkAllPerms(permission, Local.ViewMetrics)}
+            checked={checkIfAllPerms(permission, Local.ViewMetrics)}
         />
         View Metrics
     </label>
@@ -171,7 +171,7 @@
             type="checkbox"
             name="perms"
             value={Local.ViewInbox}
-            checked={checkAllPerms(permission, Local.ViewInbox)}
+            checked={checkIfAllPerms(permission, Local.ViewInbox)}
         />
         View Inbox
     </label>

--- a/client/src/components/ui/forms/permissions/util.ts
+++ b/client/src/components/ui/forms/permissions/util.ts
@@ -1,6 +1,11 @@
 import { Global, Local } from '../../../../../../model/src/permission.ts';
 
-export function checkPerms(perms: number, mask: Global | Local) {
+export function checkAllPerms(perms: number, mask: Global | Local) {
     const bits = Number(mask);
     return (perms & bits) === bits;
+}
+
+export function checkAnyPerms(perms: number, mask: Global | Local) {
+    const bits = Number(mask);
+    return (perms & bits) !== 0;
 }

--- a/client/src/components/ui/forms/permissions/util.ts
+++ b/client/src/components/ui/forms/permissions/util.ts
@@ -1,6 +1,6 @@
 import { Global, Local } from '../../../../../../model/src/permission.ts';
 
-export function checkAllPerms(perms: number, mask: Global | Local) {
+export function checkIfAllPerms(perms: number, mask: Global | Local) {
     const bits = Number(mask);
     return (perms & bits) === bits;
 }

--- a/client/src/components/ui/navigationbar/SideDrawer.svelte
+++ b/client/src/components/ui/navigationbar/SideDrawer.svelte
@@ -77,12 +77,12 @@
                 {#if checkAnyPerms(localPermission, Local.ViewBatch)}
                     <a href="#/barcodes" use:active><BarcodesIcon alt="Go to Barcodes" />Barcodes</a>
                 {/if}
-                {#if checkAnyPerms(localPermission, Local.AddInvite 
+                {#if checkAnyPerms(localPermission, Local.AddInvite
                     | Local.RevokeInvite)}
                     <a href="#/invites" use:active><InvitesIcon alt="Manage Invites" />Invites</a>
                 {/if}
-                {#if checkAnyPerms(localPermission, Local.AddStaff 
-                    | Local.RemoveStaff 
+                {#if checkAnyPerms(localPermission, Local.AddStaff
+                    | Local.RemoveStaff
                     | Local.UpdateStaff)}
                     <a href="#/staff" use:active><StaffIcon alt="Manage Staff" />Staff</a>
                 {/if}
@@ -91,9 +91,9 @@
                 {#if checkAnyPerms(globalPermission, Global.UpdateUser)}
                     <a href="#/users" use:active><AdminIcon alt="Manage Users" />Users</a>
                 {/if}
-                {#if checkAnyPerms(globalPermission, Global.CreateCategory 
-                    | Global.UpdateCategory 
-                    | Global.DeleteCategory 
+                {#if checkAnyPerms(globalPermission, Global.CreateCategory
+                    | Global.UpdateCategory
+                    | Global.DeleteCategory
                     | Global.ActivateCategory)}
                     <a href="#/categories" use:active><SettingsIcon alt="Manage Categories" />Categories</a>
                 {/if}

--- a/client/src/components/ui/navigationbar/SideDrawer.svelte
+++ b/client/src/components/ui/navigationbar/SideDrawer.svelte
@@ -3,14 +3,14 @@
 
     import type { Office } from '~model/office.ts';
     import type { User } from '~model/user.ts';
-    import { Local } from '../../../../../model/src/permission.ts';
+    import { checkAnyPerms } from '../forms/permissions/util.ts';
+    import { Local, Global } from '../../../../../model/src/permission.ts';
 
     import { userOffices, userSession } from '../../../stores/UserStore.ts';
     import { dashboardState } from '../../../stores/DashboardState.ts';
 
     import { ButtonType, IconColor } from '../../types.ts';
     import { goToTrackingPage } from '../itemrow/util.ts';
-    import { checkPerms } from '../forms/permissions/util.ts';
 
     import AdminIcon from '../../icons/PersonInfo.svelte';
     import BarcodesIcon from '../../icons/Barcode.svelte';
@@ -46,6 +46,7 @@
     $: localPermission = selectedOffice === null
         ? null
         : $userSession?.local_perms[selectedOffice] ?? null;
+    $: globalPermission = $userSession?.global_perms ?? null;
 </script>
 
 <nav class:show on:click|stopPropagation on:keypress>
@@ -66,22 +67,42 @@
             <TextInput name="trackingnumber" placeholder="Enter tracking number here..." label="" bind:value={trackingNumber} />
         </header>
         <section>
-            {#if localPermission && checkPerms(localPermission, Local.ViewInbox)}
-                <a href="#/inbox" use:active><InboxIcon alt="Go to Inbox" />Inbox</a>
-                <a href="#/outbox" use:active><OutboxIcon alt="Go to Outbox" />Outbox</a>
-                <a href="#/dossier" use:active><Document alt="Go to Dossier" />Dossier</a>
+            {#if localPermission}
+                {#if checkAnyPerms(localPermission, Local.ViewInbox)}
+                    <a href="#/inbox" use:active><InboxIcon alt="Go to Inbox" />Inbox</a>
+                    <a href="#/outbox" use:active><OutboxIcon alt="Go to Outbox" />Outbox</a>
+                    <a href="#/dossier" use:active><Document alt="Go to Dossier" />Dossier</a>
+                {/if}
+                <a href="#/metrics" use:active><ChartClusterBar alt="Go to Metrics" />Metrics</a>
+                {#if checkAnyPerms(localPermission, Local.ViewBatch)}
+                    <a href="#/barcodes" use:active><BarcodesIcon alt="Go to Barcodes" />Barcodes</a>
+                {/if}
+                {#if checkAnyPerms(localPermission, Local.AddInvite 
+                    | Local.RevokeInvite)}
+                    <a href="#/invites" use:active><InvitesIcon alt="Manage Invites" />Invites</a>
+                {/if}
+                {#if checkAnyPerms(localPermission, Local.AddStaff 
+                    | Local.RemoveStaff 
+                    | Local.UpdateStaff)}
+                    <a href="#/staff" use:active><StaffIcon alt="Manage Staff" />Staff</a>
+                {/if}
             {/if}
-            <a href="#/metrics" use:active><ChartClusterBar alt="Go to Metrics" />Metrics</a>
-            {#if localPermission && checkPerms(localPermission, Local.ViewBatch)}
-                <a href="#/barcodes" use:active><BarcodesIcon alt="Go to Barcodes" />Barcodes</a>
+            {#if globalPermission}
+                {#if checkAnyPerms(globalPermission, Global.UpdateUser)}
+                    <a href="#/users" use:active><AdminIcon alt="Manage Users" />Users</a>
+                {/if}
+                {#if checkAnyPerms(globalPermission, Global.CreateCategory 
+                    | Global.UpdateCategory 
+                    | Global.DeleteCategory 
+                    | Global.ActivateCategory)}
+                    <a href="#/categories" use:active><SettingsIcon alt="Manage Categories" />Categories</a>
+                {/if}
+                {#if checkAnyPerms(globalPermission, Global.CreateOffice | Global.UpdateOffice)}
+                    <a href="#/offices" use:active><EventsIcon alt="Go to Offices" />Offices</a>
+                {/if}
             {/if}
-            <a href="#/invites" use:active><InvitesIcon alt="Manage Invites" />Invites</a>
-            <a href="#/staff" use:active><StaffIcon alt="Manage Staff" />Staff</a>
-            <a href="#/users" use:active><AdminIcon alt="Manage Users" />Users</a>
-            <a href="#/categories" use:active><SettingsIcon alt="Manage Categories" />Categories</a>
-            <a href="#/offices" use:active><EventsIcon alt="Go to Offices" />Offices</a>
         </section>
-    </main>
+    <main>
     <form id="logout" method="POST" action="/auth/logout">
         <input type="submit" value="Logout" />
     </form>

--- a/client/src/components/ui/navigationbar/SideDrawer.svelte
+++ b/client/src/components/ui/navigationbar/SideDrawer.svelte
@@ -102,7 +102,7 @@
                 {/if}
             {/if}
         </section>
-    <main>
+    </main>
     <form id="logout" method="POST" action="/auth/logout">
         <input type="submit" value="Logout" />
     </form>


### PR DESCRIPTION
This PR aims to:
- Implement deep permission-based visibility, that is, if no permission is set in the corresponding to the subpage, then the subpage item is not visible to the side drawer.