### PR TITLE
feat(client): implement staff adder button

### DIFF
--- a/client/src/components/ui/Button.svelte
+++ b/client/src/components/ui/Button.svelte
@@ -10,8 +10,6 @@
 </button>
 
 <style>
-    @import url('../../pages/vars.css');
-
     button {
         margin: var(--spacing-normal);
         padding: var(--spacing-large);

--- a/client/src/components/ui/Modal.svelte
+++ b/client/src/components/ui/Modal.svelte
@@ -24,9 +24,6 @@
 </dialog>
 
 <style>
-    /* https://svelte.dev/examples/modal */
-    @import url('../../pages/vars.css');
-
     dialog {
         border-radius: var(--border-radius);
         border: none;

--- a/client/src/components/ui/forms/office/NewOffice.svelte
+++ b/client/src/components/ui/forms/office/NewOffice.svelte
@@ -51,12 +51,14 @@
             name="officename"
             label="New Office Name:"
         />
-        <Button submit><Checkmark color={IconColor.White} alt="Create New Office"/> New Office</Button>
+        <Button submit>
+            <Checkmark color={IconColor.White} alt="Create New Office"/>
+            New Office
+        </Button>
     </form>
 </article>
 
 <style>
-    @import url('../../../../pages/vars.css');
     section {
         overflow-y: scroll;
         border: var(--spacing-tiny) solid;

--- a/client/src/components/ui/forms/staff/AddStaff.svelte
+++ b/client/src/components/ui/forms/staff/AddStaff.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+
+    import type { Staff } from '~model/staff.ts';
+
+    import { assert } from '../../../../assert.ts';
+    import { Staff as Api } from '../../../../api/staff.ts';
+    import { Events, IconColor, ToastType } from '../../../types.ts';
+
+    import { staffList } from '../../../../stores/StaffStore.ts';
+    import { topToastMessage } from '../../../../stores/ToastStore.ts';
+
+    import Button from '../../Button.svelte';
+    import PersonAdd from '../../../icons/PersonAdd.svelte';
+
+    export let office: Staff['office'];
+
+    const dispatch = createEventDispatcher();
+    async function handleAdd() {
+        try {
+            await Api.add({ oid: office });
+            await staffList.reload?.();
+            topToastMessage.enqueue({
+                type: ToastType.Success,
+                title: 'Staff Member Added',
+                body: 'You have successfully added a new staff member.',
+            });
+            dispatch(Events.Done);
+        } catch (err) {
+            assert(err instanceof Error);
+            topToastMessage.enqueue({ title: err.name, body: err.message });
+        }
+    }
+</script>
+
+<form on:submit|self|preventDefault|stopPropagation={handleAdd}>
+    <Button submit>
+        <PersonAdd color={IconColor.White} alt="icon for removing a staff member" />
+        Add Existing User to Staff
+    </Button>
+</form>

--- a/client/src/components/ui/forms/staff/RemoveStaff.svelte
+++ b/client/src/components/ui/forms/staff/RemoveStaff.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
+
+    import type { Staff } from '~model/staff.ts';
+    import type { User } from '~model/user.ts';
+
     import { assert } from '../../../../assert.ts';
     import { Staff as Api } from '../../../../api/staff.ts';
-    import { Staff } from '~model/staff.ts';
-    import { User } from '~model/user.ts';
-    
+    import { ButtonType, Events, IconColor, ToastType } from '../../../types.ts';
+
     import { staffList } from '../../../../stores/StaffStore.ts';
     import { allOffices } from '../../../../stores/OfficeStore.ts';
     import { topToastMessage } from '../../../../stores/ToastStore.ts';
-    
+
     import Button from '../../Button.svelte';
     import PersonDelete from '../../../icons/PersonDelete.svelte';
-    import { ButtonType, Events, IconColor, ToastType } from '../../../types.ts';
-    
 
     export let id: Staff['user_id'];
     export let office: Staff['office'];
@@ -39,8 +40,8 @@
     }
 </script>
 
-
 <p>Are you sure you want to remove {email} from {$allOffices[office]}?</p>
 <Button type={ButtonType.Danger} on:click={handleRemove}>
-    <PersonDelete color={IconColor.White} alt="Remove Staff" on:click/>Remove Staff
+    <PersonDelete color={IconColor.White} alt="Remove Staff" on:click />
+    Remove Staff
 </Button>

--- a/client/src/pages/dashboard/views/Office.svelte
+++ b/client/src/pages/dashboard/views/Office.svelte
@@ -70,7 +70,7 @@
     <Modal showModal title="Create New Office" on:close={resetContext}>
         <NewOffice on:done={resetContext} />
     </Modal>
-{:else if ctx.mode === OfficeEvents.Edit || ctx.id}
+{:else if ctx.mode === OfficeEvents.Edit && typeof ctx.id !== 'undefined'}
     <Modal showModal title="Edit Office" on:close={resetContext}>
         <EditOffice currId={ctx.id} on:done={resetContext} />
     </Modal>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { Staff } from '~model/staff.ts';
-    import { User } from '~model/user.ts';
+    import type { StaffMember } from '~model/api.ts';
 
     import { assert } from '../../../assert.ts';
     import { IconColor, IconSize, ContainerType } from '../../../components/types.ts';
@@ -21,43 +20,31 @@
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
 
-    enum ActiveMenu {
+    enum SelectedMenu {
+        EditLocalPermissions,
         RemoveStaff,
-        EditStaff,
     }
 
-    interface Context {
-        id: Staff['user_id'],
-        office: Staff['office'],
-        email: User['email'],
-        permission: Staff['permission'],
-        showContext: boolean,
-        activeMenu: ActiveMenu | null;
-    }
+    type ExtraContext = { selected: SelectedMenu | null }
+    let ctx = false as ExtraContext & Omit<StaffMember, 'picture' | 'name'> | boolean;
 
     $: ({ currentOffice } = $dashboardState);
     $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
 
-    let ctx = null as Context | null;
-
-    function openContextMenu(id: Staff['user_id'], office: Staff['office'], email: User['email'], permission: Staff['permission']) {
-        ctx = { id: id, office: office, email: email, permission: permission, showContext: true, activeMenu: null };
+    function openEditLocalPermissions() {
+        assert(typeof ctx === 'object');
+        ctx.selected = SelectedMenu.EditLocalPermissions;
+        ctx = ctx;
     }
 
-    function openEditStaff(ctxcpy: Context) {
-        ctxcpy.showContext = false;
-        ctxcpy.activeMenu = ActiveMenu.EditStaff;
-        ctx = ctxcpy;
-    }
-
-    function openRemoveStaff(ctxcpy: Context) {
-        ctxcpy.showContext = false;
-        ctxcpy.activeMenu = ActiveMenu.RemoveStaff;
-        ctx = ctxcpy;
+    function openRemoveStaff() {
+        assert(typeof ctx === 'object');
+        ctx.selected = SelectedMenu.RemoveStaff;
+        ctx = ctx;
     }
 
     function resetContext() {
-        ctx = null;
+        ctx = false;
     }
 
     const staffReady = staffList.load().catch(err => {
@@ -75,7 +62,7 @@
     {:then}
         <header>
             <h1>Staffs of {officeName}</h1>
-            <Button>
+            <Button on:click={() => (ctx = true)}>
                 <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
                 Add Existing User
             </Button>
@@ -91,7 +78,7 @@
                     {picture}
                     office={currentOffice}
                     iconSize={IconSize.Large} 
-                    on:overflowClick={openContextMenu.bind(null, id, currentOffice, email, permission)} 
+                    on:overflowClick={() => (ctx = { id, email, permission, selected: null })} 
                 />
             {:else}
                 <p>No staff members exist in "{officeName}".</p>
@@ -100,38 +87,37 @@
     {:catch err}
         <PageUnavailable {err} />
     {/await}
-{/if}
-
-{#if ctx === null}
-    <!-- Do not render anything! -->
-{:else if ctx.activeMenu === ActiveMenu.AddStaff}
-    <Modal title="Add Existing User" showModal>
-        <AddStaff on:done={resetContext} office={ctx.office} />
-    </Modal>
-{:else if ctx.activeMenu === ActiveMenu.RemoveStaff}
-    <Modal title="Remove Staff" showModal>
-        <RemoveStaff
-            on:done={resetContext}
-            id={ctx.id}
-            office={ctx.office} 
-            email={ctx.email}
-        />
-    </Modal>
-{:else if ctx.activeMenu === ActiveMenu.EditStaff}
-    <Modal title="Edit Local Permissions" showModal>
-        <LocalPermissions
-            on:done={resetContext}
-            officeId={ctx.office}
-            permission={ctx.permission}
-            userId={ctx.id}
-            email={ctx.email}
-        />
-    </Modal>
-{:else if ctx.showContext}
-    <PersonContextLocal
-        on:close={resetContext}
-        show
-        on:editLocalPermission={openEditStaff.bind(null, ctx)}
-        on:removeStaff={openRemoveStaff.bind(null, ctx)}
-    />
+    {#if typeof ctx === 'object'}
+        {#if ctx.selected === SelectedMenu.EditLocalPermissions}
+            <Modal showModal on:close={resetContext} title="Edit Local Permissions">
+                <LocalPermissions
+                    on:done={resetContext}
+                    officeId={currentOffice}
+                    permission={ctx.permission}
+                    userId={ctx.id}
+                    email={ctx.email}
+                />
+            </Modal>
+        {:else if ctx.selected === SelectedMenu.RemoveStaff}
+            <Modal showModal on:close={resetContext} title="Remove Staff">
+                <RemoveStaff
+                    on:done={resetContext}
+                    office={currentOffice} 
+                    id={ctx.id}
+                    email={ctx.email}
+                />
+            </Modal>
+        {:else if ctx.selected === null}
+            <PersonContextLocal
+                show
+                on:close={resetContext}
+                on:editLocalPermission={openEditLocalPermissions}
+                on:removeStaff={openRemoveStaff}
+            />
+        {/if}
+    {:else if ctx}
+        <Modal showModal on:close={resetContext} title="Add Existing User">
+            <AddStaff on:done={resetContext} office={currentOffice} />
+        </Modal>
+    {/if}
 {/if}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -10,6 +10,7 @@
     import { allOffices } from '../../../stores/OfficeStore.ts';
     import { topToastMessage } from '../../../stores/ToastStore.ts';
 
+    import AddStaff from '../../../components/ui/forms/staff/AddStaff.svelte';
     import Button from '../../../components/ui/Button.svelte';
     import Container from '../../../components/ui/Container.svelte';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
@@ -21,8 +22,8 @@
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
 
     enum ActiveMenu {
-        EditStaff,
         RemoveStaff,
+        EditStaff,
     }
 
     interface Context {
@@ -103,15 +104,9 @@
 
 {#if ctx === null}
     <!-- Do not render anything! -->
-{:else if ctx.activeMenu === ActiveMenu.EditStaff}
-    <Modal title="Edit Local Permissions" showModal>
-        <LocalPermissions
-            on:done={resetContext}
-            officeId={ctx.office}
-            permission={ctx.permission}
-            userId={ctx.id}
-            email={ctx.email}
-        />
+{:else if ctx.activeMenu === ActiveMenu.AddStaff}
+    <Modal title="Add Existing User" showModal>
+        <AddStaff on:done={resetContext} office={ctx.office} />
     </Modal>
 {:else if ctx.activeMenu === ActiveMenu.RemoveStaff}
     <Modal title="Remove Staff" showModal>
@@ -119,6 +114,16 @@
             on:done={resetContext}
             id={ctx.id}
             office={ctx.office} 
+            email={ctx.email}
+        />
+    </Modal>
+{:else if ctx.activeMenu === ActiveMenu.EditStaff}
+    <Modal title="Edit Local Permissions" showModal>
+        <LocalPermissions
+            on:done={resetContext}
+            officeId={ctx.office}
+            permission={ctx.permission}
+            userId={ctx.id}
             email={ctx.email}
         />
     </Modal>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -17,7 +17,6 @@
     import PageUnavailable from '../../../components/ui/PageUnavailable.svelte';
     import PersonAdd from '../../../components/icons/PersonAdd.svelte';
     import PersonContextLocal from '../../../components/ui/contextdrawer/PersonContextLocal.svelte';
-    import PersonDelete from '../../../components/icons/PersonDelete.svelte';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
 

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -3,24 +3,27 @@
     import { User } from '~model/user.ts';
 
     import { assert } from '../../../assert.ts';
-    import { IconSize, ContainerType } from '../../../components/types.ts';
+    import { IconColor, IconSize, ContainerType } from '../../../components/types.ts';
 
     import { dashboardState } from '../../../stores/DashboardState.ts';
     import { staffList } from '../../../stores/StaffStore.ts';
     import { allOffices } from '../../../stores/OfficeStore.ts';
     import { topToastMessage } from '../../../stores/ToastStore.ts';
 
+    import Button from '../../../components/ui/Button.svelte';
     import Container from '../../../components/ui/Container.svelte';
     import LocalPermissions from '../../../components/ui/forms/permissions/LocalPermissions.svelte';
     import Modal from '../../../components/ui/Modal.svelte';
     import PageUnavailable from '../../../components/ui/PageUnavailable.svelte';
+    import PersonAdd from '../../../components/icons/PersonAdd.svelte';
     import PersonContextLocal from '../../../components/ui/contextdrawer/PersonContextLocal.svelte';
+    import PersonDelete from '../../../components/icons/PersonDelete.svelte';
     import PersonRowLocal from '../../../components/ui/itemrow/PersonRowLocal.svelte';
     import RemoveStaff from '../../../components/ui/forms/staff/RemoveStaff.svelte';
 
     enum ActiveMenu {
         EditStaff,
-        RemoveStaff
+        RemoveStaff,
     }
 
     interface Context {
@@ -34,7 +37,6 @@
 
     $: ({ currentOffice } = $dashboardState);
     $: officeName = currentOffice === null ? 'No office name.' : $allOffices[currentOffice];
-
 
     let ctx = null as Context | null;
 
@@ -73,7 +75,10 @@
     {:then}
         <header>
             <h1>Staffs of {officeName}</h1>
-            <!-- TODO: Put addStaff button here. -->
+            <Button>
+                <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
+                Add Existing User
+            </Button>
         </header>
         <Container ty={ContainerType.Enumeration}>
             {@const staff = $staffList.filter(s => s.permission !== 0)}

--- a/server/deno.json
+++ b/server/deno.json
@@ -4,13 +4,13 @@
         "strict": true
     },
     "tasks": {
-        "init": "initdb -D data -U postgres -W",
+        "init": "initdb -D data -U postgres",
         "db": "postgres -D data",
-        "template": "psql -U postgres -W -f db/init.sql -1 template1",
-        "create": "createdb -U postgres -W doctrack",
-        "drop": "dropdb -U postgres -W doctrack",
-        "bootstrap": "psql -U postgres -W -f db/bootstrap.sql -1 doctrack",
-        "shell": "psql -U postgres -W doctrack",
+        "template": "psql -U postgres -f db/init.sql -1 template1",
+        "create": "createdb -U postgres doctrack",
+        "drop": "dropdb -U postgres doctrack",
+        "bootstrap": "psql -U postgres -f db/bootstrap.sql -1 doctrack",
+        "shell": "psql -U postgres doctrack",
         "test": "deno test --allow-env --allow-net",
         "start": "deno run --allow-env --allow-net --allow-read src/main.ts",
         "vapid": "deno run scripts/vapid.ts"

--- a/server/src/routes/mod.ts
+++ b/server/src/routes/mod.ts
@@ -20,7 +20,7 @@ import {
     handleGetDossier,
     handleGetInbox,
     handleGetPaperTrail,
-    handleGetOutbox
+    handleGetOutbox,
 } from './api/document.ts';
 import { handleAddInvitation, handleRevokeInvitation, handleGetInvitedList } from './api/invite.ts';
 import {


### PR DESCRIPTION
Blocked on #130. Continues the work from #129 and finally closes #117.

This PR implements the staff adder button, which allows an office administrator to manually add existing users into an office (assuming that the office administrator already knows the user's Google ID). In the process, I was able to refactor the `Staff.svelte` subview to use the state machine pattern.