### PR TITLE
feat(client): display staff without permissions

### DIFF
--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -25,7 +25,7 @@
         RemoveStaff,
     }
 
-    type ExtraContext = { selected: SelectedMenu | null }
+    interface ExtraContext { selected: SelectedMenu | null }
     let ctx = false as ExtraContext & Omit<StaffMember, 'picture' | 'name'> | boolean;
 
     $: ({ currentOffice } = $dashboardState);
@@ -70,7 +70,7 @@
                     Add Existing User
                 </Button>
                 {#if !showUnprev}
-                <Button on:click={() => {showUnprev = true;}}>Show Inactive Staff</Button>
+                    <Button on:click={() => {showUnprev = true;}}>Show Inactive Staff</Button>
                 {/if}
             </div>
         </header>
@@ -98,8 +98,8 @@
             <Container ty={ContainerType.Divider}>
                 <h2>Inactive Staff</h2>
                 <Container ty={ContainerType.Enumeration}>
-                    {@const staff = $staffList.filter(s => s.permission === 0)}
-                    {#each staff as { id, name, email, permission, picture } (id)}
+                    {@const inactive = $staffList.filter(s => s.permission === 0)}
+                    {#each inactive as { id, name, email, permission, picture } (id)}
                         <PersonRowLocal
                             {id}
                             {email}

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -25,7 +25,10 @@
         RemoveStaff,
     }
 
-    interface ExtraContext { selected: SelectedMenu | null }
+    interface ExtraContext {
+        selected: SelectedMenu | null;
+    }
+
     let ctx = false as ExtraContext & Omit<StaffMember, 'picture' | 'name'> | boolean;
 
     $: ({ currentOffice } = $dashboardState);
@@ -70,7 +73,7 @@
                     Add Existing User
                 </Button>
                 {#if !showUnprev}
-                    <Button on:click={() => {showUnprev = true;}}>Show Inactive Staff</Button>
+                    <Button on:click={() => (showUnprev = true)}>Show Inactive Staff</Button>
                 {/if}
             </div>
         </header>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -56,7 +56,7 @@
         throw err;
     });
 
-    let showUnprev = false;
+    let showInactive = false;
 </script>
 
 {#if currentOffice === null}
@@ -72,8 +72,8 @@
                     <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
                     Add Existing User
                 </Button>
-                {#if !showUnprev}
-                    <Button on:click={() => (showUnprev = true)}>Show Inactive Staff</Button>
+                {#if !showInactive}
+                    <Button on:click={() => (showInactive = true)}>Show Inactive Staff</Button>
                 {/if}
             </div>
         </header>
@@ -97,7 +97,7 @@
                 {/each}
             </Container>
         </Container>
-        {#if showUnprev}
+        {#if showInactive}
             <Container ty={ContainerType.Divider}>
                 <h2>Inactive Staff</h2>
                 <Container ty={ContainerType.Enumeration}>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -52,6 +52,8 @@
         topToastMessage.enqueue({ title: err.name, body: err.message });
         throw err;
     });
+
+    let showUnprev = false;
 </script>
 
 {#if currentOffice === null}
@@ -62,28 +64,58 @@
     {:then}
         <header>
             <h1>Staffs of {officeName}</h1>
-            <Button on:click={() => (ctx = true)}>
-                <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
-                Add Existing User
-            </Button>
+            <div>
+                <Button on:click={() => (ctx = true)}>
+                    <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
+                    Add Existing User
+                </Button>
+                {#if !showUnprev}
+                <Button on:click={() => {showUnprev = true;}}>Show Inactive Staff</Button>
+                {/if}
+            </div>
         </header>
-        <Container ty={ContainerType.Enumeration}>
-            {@const staff = $staffList.filter(s => s.permission !== 0)}
-            {#each staff as { id, name, email, permission, picture } (id)}
-                <PersonRowLocal
-                    {id}
-                    {email}
-                    {name}
-                    {permission}
-                    {picture}
-                    office={currentOffice}
-                    iconSize={IconSize.Large} 
-                    on:overflowClick={() => (ctx = { id, email, permission, selected: null })} 
-                />
-            {:else}
-                <p>No staff members exist in "{officeName}".</p>
-            {/each}
+        <Container ty={ContainerType.Divider}>
+            <h2>Active Staff</h2>
+            <Container ty={ContainerType.Enumeration}>
+                {@const staff = $staffList.filter(s => s.permission !== 0)}
+                {#each staff as { id, name, email, permission, picture } (id)}
+                    <PersonRowLocal
+                        {id}
+                        {email}
+                        {name}
+                        {permission}
+                        {picture}
+                        office={currentOffice}
+                        iconSize={IconSize.Large} 
+                        on:overflowClick={() => (ctx = { id, email, permission, selected: null })} 
+                    />
+                {:else}
+                    <p>No staff members exist in "{officeName}".</p>
+                {/each}
+            </Container>
         </Container>
+        {#if showUnprev}
+            <Container ty={ContainerType.Divider}>
+                <h2>Inactive Staff</h2>
+                <Container ty={ContainerType.Enumeration}>
+                    {@const staff = $staffList.filter(s => s.permission === 0)}
+                    {#each staff as { id, name, email, permission, picture } (id)}
+                        <PersonRowLocal
+                            {id}
+                            {email}
+                            {name}
+                            {permission}
+                            {picture}
+                            office={currentOffice}
+                            iconSize={IconSize.Large} 
+                            on:overflowClick={() => (ctx = { id, email, permission, selected: null })} 
+                        />
+                    {:else}
+                        <p>No staff inactive staff members exist in "{officeName}".</p>
+                    {/each}
+                </Container>
+            </Container>
+        {/if}
     {:catch err}
         <PageUnavailable {err} />
     {/await}
@@ -121,3 +153,16 @@
         </Modal>
     {/if}
 {/if}
+
+<style>
+    header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    div {
+        display: flex;
+        align-items: column;
+    }
+</style>

--- a/client/src/pages/dashboard/views/Staff.svelte
+++ b/client/src/pages/dashboard/views/Staff.svelte
@@ -56,7 +56,7 @@
         throw err;
     });
 
-    let showInactive = false;
+    let showRetiredStaff = false;
 </script>
 
 {#if currentOffice === null}
@@ -72,8 +72,8 @@
                     <PersonAdd color={IconColor.White} alt="icon for adding an existing user"></PersonAdd>
                     Add Existing User
                 </Button>
-                {#if !showInactive}
-                    <Button on:click={() => (showInactive = true)}>Show Inactive Staff</Button>
+                {#if !showRetiredStaff}
+                    <Button on:click={() => (showRetiredStaff = true)}>Show Inactive Staff</Button>
                 {/if}
             </div>
         </header>
@@ -97,7 +97,7 @@
                 {/each}
             </Container>
         </Container>
-        {#if showInactive}
+        {#if showRetiredStaff}
             <Container ty={ContainerType.Divider}>
                 <h2>Inactive Staff</h2>
                 <Container ty={ContainerType.Enumeration}>


### PR DESCRIPTION
This PR aims to add a selection to show staff that have no permissions so that a person with authority can escalate their permissions as needed. Continues #132  , finally resolves #117.