### PR TITLE
fix(client): fix erroneous QR assignment

### DIFF
--- a/client/src/pages/track/Track.svelte
+++ b/client/src/pages/track/Track.svelte
@@ -133,7 +133,7 @@
                 {@const { title, category, mime, trail } = meta}
                 {@const overview = renderOverview(trail, $allOffices)}
                 <section>
-                    <QrGenerator url={title} />
+                    <QrGenerator url={trackingNumber} />
                     <div class="column">
                         <p>Tracking No: {trackingNumber}</p>
                         <h1 class="removemargin">{title}</h1>


### PR DESCRIPTION
Don't ask Marc why the QR code said `this is some document` inside its decoded QR code. You won't believe the answer.